### PR TITLE
feat: add agent skills architecture and ADR framework

### DIFF
--- a/.agents/ai-generative/SKILL.md
+++ b/.agents/ai-generative/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: ai-generative
+description: AI provider integration for invoice scanning. ProviderInterface contract, OpenAI/Gemini/Mistral implementations, extraction prompts, schema validation, confidence scoring, PDF/image processing, base64 encoding.
+---
+
+# AI & Generative — AiScan Provider Integration
+
+## Provider Architecture
+
+All AI providers implement `ProviderInterface`:
+
+```php
+interface ProviderInterface {
+    public function getName(): string;
+    public function isAvailable(): bool;
+    public function analyzeDocument(
+        string $content,
+        string $mimeType,
+        string $prompt,
+        string $systemPrompt
+    ): string;
+}
+```
+
+### Available Providers
+
+| Provider | Class | Default Model | API |
+|---|---|---|---|
+| OpenAI | `OpenAIProvider` | `gpt-5-mini` | Chat Completions |
+| Gemini | `GeminiProvider` | `gemini-2.5-flash` | GenerateContent |
+| Mistral | `MistralProvider` | `mistral-small-latest` | Chat Completions |
+| Custom | `OpenAICompatibleProvider` | User-configured | OpenAI-compatible |
+
+### Adding a New Provider
+1. Create `Lib/Provider/{Name}Provider.php` implementing `ProviderInterface`
+2. Register in `ExtractionService::getProvider()` switch
+3. Add settings keys in `AiScanSettings::getDefaults()` (`{name}_api_key`, `{name}_model`)
+4. Add UI group in `XMLView/AiScanConfig.xml`
+5. Add translations in `Translation/*.json`
+
+## Extraction Flow
+
+```
+File upload → MIME detection → Content encoding → Prompt assembly → API call → JSON parse → Schema validation → Supplier matching → Return
+```
+
+### Content Encoding by Type
+
+| MIME Type | Encoding | Method |
+|---|---|---|
+| `image/jpeg`, `image/png`, `image/webp` | Base64 data URI | `data:{mime};base64,{content}` |
+| `application/pdf` | Text extraction first | `pdftotext` via shell, fallback to base64 |
+| `application/octet-stream` | Detected by extension | Route to image or PDF handling |
+
+### PDF Processing Strategy
+1. **Try `pdftotext`** — fast, lightweight, works for text-based PDFs
+2. **If no text extracted** — fall back to base64 encoding (scanned/image PDFs)
+3. **Text is injected** into the execution prompt as additional context
+4. Provider receives both: extracted text (if any) + base64 document
+
+## Prompt System
+
+### System Prompt
+- Stored in `Settings('AiScan', 'extraction_prompt')`
+- Customizable by user via AiScanConfig panel
+- Defines the expected JSON schema for extraction output
+- Default loaded from `ExtractionService::getDefaultSystemPrompt()`
+
+### Execution Prompt
+- Built per-request by `ExtractionService`
+- Injects placeholders: `{{FILE_NAME}}`, `{{MIME_TYPE}}`
+- Includes extracted PDF text when available
+- Instructions to return **only JSON**, no markdown wrapping
+
+## Extraction Schema
+
+The AI must return this JSON structure:
+
+```json
+{
+  "document_type": "invoice|receipt|proforma|credit_note|unknown",
+  "supplier": {
+    "name": "string",
+    "tax_id": "string",
+    "email": "string|null",
+    "phone": "string|null",
+    "website": "string|null",
+    "address": "string|null"
+  },
+  "customer": { "name": "string", "tax_id": "string", "address": "string|null" },
+  "invoice": {
+    "number": "string (required)",
+    "issue_date": "YYYY-MM-DD (required)",
+    "due_date": "YYYY-MM-DD|null",
+    "currency": "ISO 4217 3-letter",
+    "subtotal": "number",
+    "tax_amount": "number",
+    "withholding_amount": "number",
+    "total": "number (required)",
+    "summary": "string|null",
+    "payment_terms": "string|null"
+  },
+  "taxes": [{ "name": "string", "rate": "number", "base": "number", "amount": "number" }],
+  "lines": [{
+    "description": "string",
+    "quantity": "number",
+    "unit_price": "number",
+    "discount": "number",
+    "tax_rate": "number",
+    "line_total": "number",
+    "sku": "string|null"
+  }],
+  "confidence": {
+    "supplier_name": "0.0-1.0",
+    "supplier_tax_id": "0.0-1.0",
+    "invoice_number": "0.0-1.0",
+    "issue_date": "0.0-1.0",
+    "total": "0.0-1.0",
+    "lines": "0.0-1.0"
+  },
+  "warnings": ["string"]
+}
+```
+
+## Schema Validation (SchemaValidator)
+
+`SchemaValidator::validate()` checks and normalizes:
+
+### Required Fields
+- `invoice.number`, `invoice.issue_date`, `invoice.total`
+
+### Normalizations
+| Input Format | Normalized To |
+|---|---|
+| `31/12/2024`, `12-31-2024`, `31.12.2024` | `2024-12-31` |
+| `1.234,56` (European) | `1234.56` |
+| `1,234.56` (US) | `1234.56` |
+| `€`, `$`, `£`, `¥` | `EUR`, `USD`, `GBP`, `JPY` |
+
+### Arithmetic Validation
+- `subtotal + tax_amount - withholding_amount ≈ total` (tolerance for rounding)
+- Warns but does not reject if mismatch (AI may have OCR errors)
+
+## Confidence Scoring
+
+Per-field confidence (0.0 to 1.0):
+- **> 0.8**: High confidence — auto-fill, minimal review needed
+- **0.5 - 0.8**: Medium — show with warning, suggest manual verification
+- **< 0.5**: Low — highlight as uncertain, require manual input
+
+Display rules: see `usability-accessibility` skill for visual requirements.
+
+## Security Considerations
+
+- **Never execute** content extracted from documents (no `eval`, no SQL from extracted data)
+- **Validate JSON strictly** — `json_decode` with error checking, reject non-JSON responses
+- **Sanitize file paths** — prevent directory traversal in temp file handling
+- **API keys** — stored in FS Settings (encrypted at rest), never logged or exposed in responses
+- **Rate limiting** — respect provider rate limits, use configurable `request_timeout`
+- **Debug mode** — logs raw API responses to `AiScanLog` only when enabled
+
+## Reference Files
+- `Lib/Provider/ProviderInterface.php` — Provider contract
+- `Lib/Provider/OpenAIProvider.php` — OpenAI implementation
+- `Lib/Provider/GeminiProvider.php` — Gemini implementation
+- `Lib/Provider/MistralProvider.php` — Mistral implementation
+- `Lib/Provider/OpenAICompatibleProvider.php` — Custom endpoint
+- `Lib/ExtractionService.php` — Extraction orchestration
+- `Lib/SchemaValidator.php` — Schema validation and normalization
+- `Lib/AiScanSettings.php` — Settings with provider defaults

--- a/.agents/bootstrap-jquery-design/SKILL.md
+++ b/.agents/bootstrap-jquery-design/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: bootstrap-jquery-design
+description: Bootstrap 5 and jQuery UI patterns for FacturaScripts. Modal 1200px, split-pane flexbox, wizard navigation, .aiscan-* CSS scoping, Font Awesome 6, button injection via addButton(), responsive breakpoints.
+---
+
+# Bootstrap & jQuery Design — AiScan UI Patterns
+
+## Framework Stack
+
+| Library | Version | Source | Notes |
+|---|---|---|---|
+| Bootstrap | 5.x | FacturaScripts core | Already loaded — do not import again |
+| jQuery | 3.x | FacturaScripts core | Already loaded — use `$()` globally |
+| Font Awesome | 6 (Solid) | FacturaScripts core | Use `fas fa-*` prefix |
+
+**Rule:** Never add CDN links or bundle these libraries — they come from FacturaScripts core.
+
+## CSS Scoping
+
+All custom CSS classes use the `.aiscan-` prefix to avoid collisions with FacturaScripts core styles:
+
+```css
+.aiscan-modal-body { }
+.aiscan-split-pane { }
+.aiscan-drop-area { }
+.aiscan-confidence-badge { }
+```
+
+**Rule:** Never override Bootstrap classes globally. Use `.aiscan-` scoped selectors or Bootstrap utility classes.
+
+## Modal Design
+
+```html
+<div class="modal fade" id="aiscanModal" tabindex="-1">
+  <div class="modal-dialog" style="max-width: 1200px;">
+    <div class="modal-content">
+      <div class="modal-header">...</div>
+      <div class="modal-body p-0"><!-- zero padding for split-pane --></div>
+      <div class="modal-footer">...</div>
+    </div>
+  </div>
+</div>
+```
+
+- **Max width:** 1200px (`style` or custom class, not `.modal-xl` which is 1140px)
+- **Body padding:** 0 — the split-pane fills the entire body
+- **Backdrop:** default Bootstrap (click outside to close)
+- See `usability-accessibility` skill for ARIA requirements
+
+## Split-Pane Layout
+
+```css
+.aiscan-split-pane {
+    display: flex;
+    height: 70vh;
+}
+.aiscan-split-left {
+    flex: 0 0 55%;     /* Document preview */
+    overflow: auto;
+}
+.aiscan-split-right {
+    flex: 0 0 45%;     /* Extracted data */
+    overflow: auto;
+}
+.aiscan-split-divider {
+    width: 4px;
+    cursor: col-resize;
+    background: var(--bs-border-color);
+}
+```
+
+- Divider is draggable via JS (mousedown/mousemove)
+- **Responsive:** below 768px, stack vertically (preview on top)
+
+```css
+@media (max-width: 767.98px) {
+    .aiscan-split-pane { flex-direction: column; }
+    .aiscan-split-left,
+    .aiscan-split-right { flex: none; width: 100%; }
+}
+```
+
+## Wizard Navigation
+
+```html
+<div class="aiscan-wizard-nav d-flex justify-content-between align-items-center p-2">
+  <button class="btn btn-secondary btn-sm" id="aiscan-prev">
+    <i class="fas fa-chevron-left"></i> Anterior
+  </button>
+  <span class="aiscan-wizard-step">Archivo 1 de 3</span>
+  <button class="btn btn-primary btn-sm" id="aiscan-next">
+    Siguiente <i class="fas fa-chevron-right"></i>
+  </button>
+</div>
+```
+
+- Previous/Next disabled when at boundaries (see `aiscan-flow.js` `getWizardMeta()`)
+- Primary action button changes label contextually (Analizar / Guardar / Siguiente)
+- Step indicator: "Archivo X de N"
+
+## Drop Area
+
+```css
+.aiscan-drop-area {
+    border: 2px dashed var(--bs-border-color);
+    border-radius: 0.5rem;
+    padding: 2rem;
+    text-align: center;
+    cursor: pointer;
+    transition: border-color 0.2s, background-color 0.2s;
+}
+.aiscan-drop-area:hover,
+.aiscan-drop-area.dragover {
+    border-color: var(--bs-primary);
+    background-color: rgba(var(--bs-primary-rgb), 0.05);
+}
+```
+
+- Accepts: PDF, JPG, JPEG, PNG, WebP
+- Visual feedback on dragover (border color change + background tint)
+- Click triggers hidden `<input type="file">`
+- Multi-file supported
+
+## Buttons
+
+### Toolbar Injection (Extension)
+Buttons are injected into FacturaScripts toolbar via the Extension pattern:
+
+```php
+// In Extension/Controller/EditFacturaProveedor.php
+$this->addButton('footer', [
+    'action' => 'scan-invoice',
+    'icon' => 'fas fa-camera',
+    'label' => 'scan-invoice',
+    'type' => 'action',
+]);
+```
+
+### Button Styles
+- **Primary action:** `btn btn-primary` (Guardar, Analizar)
+- **Secondary action:** `btn btn-secondary` (Cancelar, Anterior)
+- **Danger action:** `btn btn-danger` (Eliminar linea)
+- **Small buttons:** add `btn-sm` inside modal context
+- **Icon + text:** `<i class="fas fa-save"></i> Guardar` — always include text, not icon-only
+
+## Tables (Line Items)
+
+```html
+<table class="table table-hover table-sm">
+  <thead class="table-light">
+    <tr>
+      <th>Descripcion</th>
+      <th class="text-end">Cantidad</th>
+      <th class="text-end">Precio</th>
+      <th class="text-end">Dto%</th>
+      <th class="text-end">IVA%</th>
+      <th class="text-end">Total</th>
+      <th></th><!-- Actions -->
+    </tr>
+  </thead>
+</table>
+```
+
+- Numeric columns: `text-end` alignment
+- Editable fields: `<input class="form-control form-control-sm">`
+- Action column: icon buttons (edit, delete) with `btn-sm`
+
+## Icons (Font Awesome 6 Solid)
+
+| Action | Icon |
+|---|---|
+| Scan/Camera | `fas fa-camera` |
+| Upload | `fas fa-upload` |
+| Analyze/AI | `fas fa-brain` |
+| Save | `fas fa-save` |
+| Delete | `fas fa-trash` |
+| Edit | `fas fa-pen` |
+| Settings | `fas fa-cog` |
+| Success | `fas fa-check-circle` |
+| Warning | `fas fa-exclamation-triangle` |
+| Error | `fas fa-times-circle` |
+| Spinner | `fas fa-spinner fa-spin` |
+
+## Reference Files
+- `Assets/CSS/aiscan.css` — All custom styles
+- `Assets/JS/aiscan.js` — UI controller with DOM manipulation
+- `Extension/Controller/EditFacturaProveedor.php` — Button injection
+- `Extension/Controller/ListFacturaProveedor.php` — List view button

--- a/.agents/devops-testing/SKILL.md
+++ b/.agents/devops-testing/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: devops-testing
+description: DevOps, CI/CD and testing for AiScan. Docker workflow, Makefile commands, PHPUnit in container, JS tests via Node --test, GitHub Actions CI matrix PHP 8.1-8.4, test naming conventions.
+---
+
+# DevOps & Testing — AiScan Infrastructure
+
+## Docker Environment
+
+### Essential Commands
+```bash
+make upd          # Start containers (detached) — auto-called by lint/format/test
+make down         # Stop containers
+make shell        # Open shell inside facturascripts container
+make logs         # Tail container logs
+make fresh        # Clean volumes + restart (fresh database)
+make rebuild      # Rebuild FacturaScripts dynamic classes
+```
+
+### Container Details
+- Image: FacturaScripts with PHP 8.4 (`php84` binary, NOT `php`)
+- Plugin mounted at `/var/www/html/Plugins/AiScan/`
+- MySQL available inside container
+- Web UI: `http://localhost:8080` (admin/admin)
+
+## Validation Workflow (Sacred — Never Skip)
+
+```bash
+make format   # Step 1: PHP CS Fixer auto-fix
+make lint     # Step 2: PHPCS check (zero violations required)
+make test     # Step 3: PHPUnit + JS tests (zero failures required)
+```
+
+**Order matters.** Format first (auto-fixes), then lint (catches remaining issues), then test.
+
+## PHP Testing
+
+### Structure
+```
+Test/
+  bootstrap.php          # FacturaScripts environment setup
+  install-plugins.php    # Plugin dependency installer
+  main/                  # PHPUnit test classes
+    AiScanInvoiceControllerTest.php
+    AiScanSettingsTest.php
+    EditFacturaProveedorExtensionTest.php
+    ExtractionServiceTest.php
+    InvoiceMapperTest.php
+    SchemaValidatorTest.php
+    SupplierMatcherTest.php
+```
+
+### How `make test` Works
+1. Installs PHPUnit in container if absent
+2. Copies `Test/main/*` to container's `Test/Plugins/` directory
+3. Copies `Test/bootstrap.php` and `Test/install-plugins.php`
+4. Runs `install-plugins.php` to set up dependencies
+5. Generates `phpunit-plugins.xml` config
+6. Executes: `php84 vendor/bin/phpunit -c phpunit-plugins.xml`
+
+### Test Naming
+- File: `{ClassName}Test.php` (e.g., `SchemaValidatorTest.php`)
+- Class: `{ClassName}Test extends TestCase`
+- Methods: `test{Behavior}()` (e.g., `testValidateReturnsErrorsForMissingFields`)
+
+### Rules
+- **Never leave failing tests** — fix the issue, don't skip the test
+- **Never remove tests** to make the suite pass
+- **Add tests** when: adding new class, changing public method, fixing a bug
+- **Update tests** when: changing behavior of covered code paths
+- Tests must work inside the FacturaScripts container environment (not standalone)
+
+## JavaScript Testing
+
+### Running
+```bash
+node --test Test/js/*.test.js
+```
+
+### Structure
+```
+Test/js/
+  aiscan-flow.test.js      # Tests for UMD library (pure functions)
+  aiscan-fallback.test.js   # Tests for IIFE fallback logic
+```
+
+### Rules
+- Uses Node.js built-in `test` and `assert` modules — no external test framework
+- Tests run in Node.js (no browser, no jsdom)
+- Test pure logic only — DOM interaction tested manually or via E2E
+
+## CI Pipeline (.github/workflows/ci.yml)
+
+### Job 1: Docker Environment Test
+1. Start Docker containers
+2. Copy plugin into container
+3. Run `make lint`
+4. Run `make test`
+
+### Job 2: PHP Matrix Test
+Matrix: **PHP 8.1, 8.2, 8.3, 8.4**
+
+1. Clone FacturaScripts repository
+2. Copy plugin to `Plugins/AiScan/`
+3. Set up MySQL service
+4. Install Composer dependencies
+5. Run JS tests (`node --test`)
+6. Generate PHPUnit config
+7. Run PHPUnit tests
+
+**All PHP versions must pass.** Do not use PHP 8.2+ features unless `facturascripts.ini` min PHP is updated.
+
+## Packaging
+
+```bash
+make package VERSION=1.2.3
+```
+
+- Creates `dist/AiScan-1.2.3.zip`
+- Excludes: tests, dev configs, docs, agent files, Docker files, Git files
+- Updates version in `facturascripts.ini` during build, reverts after
+- If adding new non-distributable files/directories → add exclusion to `Makefile`
+
+## Reference Files
+- `Makefile` — All development commands
+- `.github/workflows/ci.yml` — CI pipeline
+- `docker-compose.yml` — Docker service definitions
+- `Test/` — All test files
+- `phpcs.xml` — PHPCS configuration
+- `.php-cs-fixer.php` — PHP CS Fixer configuration

--- a/.agents/documentation-adr/SKILL.md
+++ b/.agents/documentation-adr/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: documentation-adr
+description: Documentation standards and ADR process for AiScan. Keep-a-Changelog format, ADR template with Status/Context/Decision/Consequences, README/QUICKSTART sync rules, decision tracking workflow.
+---
+
+# Documentation & ADR — AiScan Decision Tracking
+
+## ADR (Architecture Decision Records)
+
+### Location
+```
+docs/adr/
+  0000-adr-template.md     # Template reference (never modified)
+  0001-*.md                # First real decision
+  0002-*.md                # Second decision
+  ...
+```
+
+### When to Create an ADR
+- Adding or removing a dependency
+- Changing architectural patterns (new provider, new service layer)
+- Security-related decisions (auth, encryption, API key storage)
+- Significant trade-offs (performance vs simplicity, compatibility vs features)
+- Choosing between alternatives (why provider X over provider Y)
+
+### ADR Format
+
+```markdown
+# ADR-NNNN: Title in Imperative Mood
+
+## Status
+Proposed | Accepted | Deprecated | Superseded by ADR-NNNN
+
+## Date
+YYYY-MM-DD
+
+## Context
+What is the problem or need motivating this decision?
+Include constraints, requirements, and forces at play.
+
+## Decision
+What has been decided and why?
+Be specific about what will be done.
+
+## Consequences
+
+### Positive
+- Benefit 1
+- Benefit 2
+
+### Negative
+- Cost or risk 1
+
+### Neutral
+- Implication without clear value judgment
+```
+
+### ADR Lifecycle
+1. **Proposed** — written but not yet agreed upon
+2. **Accepted** — agreed and in effect
+3. **Deprecated** — no longer relevant (context changed)
+4. **Superseded by ADR-NNNN** — replaced by a newer decision
+
+### Rules
+- **Numbering:** 4 digits, zero-padded: `0001`, `0002`, ...
+- **Filename:** `NNNN-title-in-kebab-case.md`
+- **Title:** imperative mood ("Use OpenAI as default provider", not "OpenAI was chosen")
+- **Immutable once accepted:** if a decision changes, create a new ADR that supersedes it
+- **Consult existing ADRs** before making decisions that could contradict them
+- **If superseding:** update the old ADR's Status to "Superseded by ADR-NNNN"
+
+## Changelog
+
+### Location
+```
+docs/CHANGELOG.md
+```
+
+### Format: Keep a Changelog
+
+```markdown
+# Changelog
+
+All notable changes to AiScan will be documented in this file.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+
+## [Unreleased]
+
+### Added
+- New feature description
+
+### Changed
+- Existing feature modification
+
+### Fixed
+- Bug fix description
+
+## [1.0.0] - 2024-XX-XX
+
+### Added
+- Initial release features
+```
+
+### Sections (in this order)
+| Section | When to use |
+|---|---|
+| **Added** | New features or capabilities |
+| **Changed** | Changes to existing functionality |
+| **Deprecated** | Features marked for future removal |
+| **Removed** | Features removed in this release |
+| **Fixed** | Bug fixes |
+| **Security** | Vulnerability patches |
+
+### Rules
+- `[Unreleased]` always at the top — accumulates changes between releases
+- On release: move `[Unreleased]` contents to `[X.Y.Z] - YYYY-MM-DD` section
+- One line per change, starting with a verb
+- Reference ADR when a change stems from an architectural decision
+
+## README & QUICKSTART Sync
+
+### README.md
+Update when:
+- User-visible behavior changes (new feature, removed feature)
+- Configuration options added or changed
+- Supported providers list changes
+- Installation requirements change
+
+### QUICKSTART.md
+Update when:
+- Docker setup steps change
+- Login credentials change
+- Plugin enable/configuration flow changes
+- New first-time setup steps needed
+
+### Translation Files
+Update `Translation/es_ES.json` and `Translation/en_EN.json` when:
+- Adding new user-visible strings (labels, messages, errors)
+- Changing existing string meanings
+- Keys: lowercase kebab-case (`scan-invoice`, `ai-provider-error`)
+
+## Reference Files
+- `docs/adr/0000-adr-template.md` — ADR template
+- `docs/CHANGELOG.md` — Project changelog
+- `README.md` — User documentation (Spanish)
+- `QUICKSTART.md` — Quick start guide
+- `Translation/es_ES.json` — Spanish translations
+- `Translation/en_EN.json` — English translations

--- a/.agents/facturascripts-plugin/SKILL.md
+++ b/.agents/facturascripts-plugin/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: facturascripts-plugin
+description: FacturaScripts 2025+ plugin architecture. Controller patterns, Extension closures, XMLView/Table XML, Model conventions, Init.php lifecycle, Settings API, AssetManager, Dinamic namespace.
+---
+
+# FacturaScripts Plugin Expert — AiScan Architecture
+
+## Plugin Lifecycle (Init.php)
+
+```php
+class Init extends InitClass {
+    public function init(): void    // Called on every request — load extensions here
+    public function update(): void  // Called on install/update — initialize settings, migrations
+    public function uninstall(): void // Called on plugin removal — cleanup
+}
+```
+
+- `init()`: Register extensions via `$this->loadExtension(new Extension\Controller\Foo())`
+- `update()`: Set default settings, run one-time migrations
+- Extensions must be loaded in `init()`, NOT `update()`
+
+## Controllers
+
+### PanelController (settings, detail views)
+```php
+class AiScanConfig extends PanelController {
+    protected function createViews(): void {
+        $this->addHtmlView('config', 'AiScanConfig', 'Settings', 'config');
+    }
+    public function getPageData(): array {
+        return ['menu' => 'admin', 'title' => 'ai-scan-config', 'icon' => 'fas fa-brain'];
+    }
+}
+```
+
+### Custom API Controller
+`AiScanInvoice` extends `Controller` directly for REST-style JSON endpoints:
+- Override `publicCore(&$response)` or handle in `privateCore()`
+- Return JSON via `$this->response->setContent(json_encode($data))`
+- Check permissions: `$this->permissions->allowUpdate`
+
+## Extension Pattern (Closure-Return)
+
+Extensions modify existing FacturaScripts controllers without editing core files:
+
+```php
+// Extension/Controller/EditFacturaProveedor.php
+class EditFacturaProveedor
+{
+    // Method name = hook point in the target controller
+    public function createViews(): Closure
+    {
+        return function () {
+            // $this = the target controller instance
+            AssetManager::addCss(FS_ROUTE . '/Plugins/AiScan/Assets/CSS/aiscan.css');
+            AssetManager::addJs(FS_ROUTE . '/Plugins/AiScan/Assets/JS/aiscan.js');
+        };
+    }
+}
+```
+
+**Rules:**
+- Method names match the target controller method they hook into
+- The closure receives `$this` as the target controller (not the extension)
+- Use `FS_ROUTE` prefix for asset paths
+- Extension class goes in `Extension/Controller/` mirroring the target controller name
+
+## Settings API
+
+```php
+// Read setting
+$value = Tools::settings('AiScan', 'key_name', 'default_value');
+
+// Write setting (in update() or controller action)
+$settings = new Settings();
+$settings->name = 'AiScan';
+$settings->properties = ['key' => 'value', ...];
+$settings->save();
+```
+
+- Settings namespace: `'AiScan'`
+- `AiScanSettings` helper in `Lib/AiScanSettings.php` wraps `Tools::settings()` with typed defaults
+
+## Asset Injection
+
+```php
+AssetManager::addCss(FS_ROUTE . '/Plugins/AiScan/Assets/CSS/aiscan.css');
+AssetManager::addJs(FS_ROUTE . '/Plugins/AiScan/Assets/JS/aiscan-flow.js');
+AssetManager::addJs(FS_ROUTE . '/Plugins/AiScan/Assets/JS/aiscan.js');
+```
+
+- Always use `FS_ROUTE` prefix — handles subfolder installations
+- Load CSS before JS
+- Load `aiscan-flow.js` before `aiscan.js` (dependency order)
+
+## Models
+
+```php
+class AiScanLog extends ModelClass {
+    public function primaryColumn(): string { return 'id'; }
+    public static function tableName(): string { return 'aiscan_logs'; }
+    public function primaryDescriptionColumn(): string { return 'filename'; }
+}
+```
+
+- Inherit from `ModelClass` for CRUD operations
+- Table schema defined in `Table/aiscan_logs.xml`
+- Use `ModelClass` methods: `loadFromCode()`, `save()`, `delete()`, `all()`, `count()`
+
+### Accessing Core Models (Dinamic Namespace)
+
+```php
+use FacturaScripts\Dinamic\Model\Proveedor;
+use FacturaScripts\Dinamic\Model\FacturaProveedor;
+use FacturaScripts\Dinamic\Model\LineaFacturaProveedor;
+```
+
+- **Always** use `Dinamic` namespace for FS core models — enables other plugins to extend them
+- Never use `FacturaScripts\Core\Model\...` directly
+
+## XMLView Definitions
+
+`XMLView/AiScanConfig.xml` defines the settings panel UI:
+```xml
+<view>
+  <columns>
+    <group name="general" title="general">
+      <column name="enabled" numcolumns="4">
+        <widget type="checkbox" fieldname="enabled" />
+      </column>
+    </group>
+  </columns>
+</view>
+```
+
+## Table Definitions
+
+`Table/aiscan_logs.xml` defines database schema:
+```xml
+<table>
+  <column><name>id</name><type>serial</type></column>
+  <column><name>filename</name><type>character varying(255)</type></column>
+  ...
+  <constraint><name>aiscan_logs_pkey</name><type>PRIMARY KEY</type><columns>id</columns></constraint>
+</table>
+```
+
+## Translation
+
+- Strings in `Translation/es_ES.json` and `Translation/en_EN.json`
+- Use `Tools::lang()->trans('key')` in PHP or `i18n.trans('key')` in Twig
+- Keys are lowercase kebab-case: `ai-scan-config`, `scan-invoice`
+
+## Reference Files
+- `Init.php` — Plugin entry point
+- `Controller/` — Main controllers
+- `Extension/Controller/` — Controller extensions
+- `Model/AiScanLog.php` — Audit log model
+- `XMLView/AiScanConfig.xml` — Settings UI
+- `Table/aiscan_logs.xml` — Database schema
+- `Lib/AiScanSettings.php` — Settings helper

--- a/.agents/javascript-expert/SKILL.md
+++ b/.agents/javascript-expert/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: javascript-expert
+description: JavaScript patterns for AiScan plugin. UMD modules (aiscan-flow.js), IIFE pattern (aiscan.js), jQuery integration, no bundler, no ES modules, Node --test runner for tests.
+---
+
+# JavaScript Expert — AiScan Frontend Patterns
+
+## Module Architecture
+
+AiScan uses **two JS files** loaded via `<script>` tags — no bundler, no ES modules.
+
+### aiscan-flow.js (UMD Library)
+- **Path:** `Assets/JS/aiscan-flow.js`
+- **Pattern:** UMD (Universal Module Definition) — works in browser and Node.js
+- **Purpose:** Pure state management functions, zero DOM dependency
+- **Exports:** `normalizeUploadResponse`, `createWizardEntries`, `getWizardMeta`, `markEntrySaved`, `getSaveInvoiceId`, `cloneValue`
+- **Rule:** No jQuery, no `document`, no `window` references (except UMD boilerplate)
+
+### aiscan.js (IIFE UI Controller)
+- **Path:** `Assets/JS/aiscan.js`
+- **Pattern:** IIFE (Immediately Invoked Function Expression)
+- **Purpose:** DOM interaction, event handling, AJAX calls, modal lifecycle
+- **Dependencies:** jQuery (global `$`), aiscan-flow.js (global `AiScanFlow`)
+- **Rule:** All DOM access goes here, never in aiscan-flow.js
+
+## Coding Rules
+
+### No Modern Module Syntax
+```javascript
+// WRONG — FacturaScripts loads scripts via <script> tags
+import { foo } from './bar.js';
+export function baz() {}
+
+// CORRECT — UMD or IIFE patterns
+(function(root, factory) {
+    if (typeof module === 'object') module.exports = factory();
+    else root.MyLib = factory();
+})(typeof self !== 'undefined' ? self : this, function() { ... });
+```
+
+### jQuery for DOM and AJAX
+```javascript
+// Use jQuery — consistent with FacturaScripts core
+$.ajax({ url: actionUrl, method: 'POST', data: formData });
+$(document).on('click', '.aiscan-btn', handler);
+
+// NOT vanilla fetch/addEventListener (compatibility)
+```
+
+### State Management
+- State is a plain object — no class instances, no Proxy
+- Deep clone via `cloneValue(obj)` → `JSON.parse(JSON.stringify(obj))`
+- Never mutate function arguments — clone first, modify clone, return clone
+
+### Event Handling
+- Use **event delegation** via `$(document).on(event, selector, handler)`
+- Keeps handlers working for dynamically inserted DOM elements
+- Clean up handlers when modal closes to prevent leaks
+
+### Error Handling
+- Wrap AJAX calls in `.fail()` handlers
+- Show user-facing errors in the modal UI — never silent failures
+- Console.log for debug info only when `debug_mode` is enabled
+
+## Testing
+
+- **Runner:** `node --test Test/js/*.test.js`
+- **Assert:** Node.js built-in `assert` module (no mocha/jest)
+- **Files:** `Test/js/aiscan-flow.test.js`, `Test/js/aiscan-fallback.test.js`
+- **Coverage:** Test pure functions from aiscan-flow.js; IIFE logic tested via fallback tests
+- **Rule:** Tests must run without browser environment (no jsdom)
+
+## Reference Files
+- `Assets/JS/aiscan-flow.js` — UMD state management library
+- `Assets/JS/aiscan.js` — IIFE UI controller
+- `Test/js/` — JavaScript test files

--- a/.agents/php-expert/SKILL.md
+++ b/.agents/php-expert/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: php-expert
+description: PHP 8.1+ coding standards for this FacturaScripts plugin. PSR-12, 120-char lines, phpcs.xml rules, .php-cs-fixer.php config, forbidden aliases, namespace conventions, LGPL-3.0 headers.
+---
+
+# PHP Expert — AiScan Coding Standards
+
+## Style Enforcement
+
+Two tools enforce style — run both via `make format` then `make lint`:
+
+| Tool | Config file | Role |
+|---|---|---|
+| PHP CS Fixer | `.php-cs-fixer.php` | Auto-fixes style (canonical formatter) |
+| PHPCS | `phpcs.xml` | Reports remaining violations (must be zero) |
+
+## Rules
+
+### Formatting
+- **PSR-12** strict — max line length **120 characters**
+- **Short array syntax**: `[]` not `array()`
+- **Single quotes** for strings unless interpolation is needed
+- **No trailing whitespace**, single blank line at EOF
+- Braces on own line for classes/methods, same line for control structures
+
+### Imports
+- No unused imports
+- Alphabetically ordered
+- One `use` per line, no group `use` statements
+
+### Forbidden Aliases
+These function aliases trigger PHPCS violations:
+
+| Forbidden | Use instead |
+|---|---|
+| `sizeof()` | `count()` |
+| `delete()` | `unset()` |
+| `print` | `echo` |
+
+### Namespace Convention
+```php
+namespace FacturaScripts\Plugins\AiScan;           // Root classes (Init.php)
+namespace FacturaScripts\Plugins\AiScan\Controller; // Controllers
+namespace FacturaScripts\Plugins\AiScan\Lib;        // Services
+namespace FacturaScripts\Plugins\AiScan\Lib\Provider; // AI providers
+namespace FacturaScripts\Plugins\AiScan\Model;      // Models
+```
+
+### Type Safety
+- Type hints on all method parameters and return types
+- `?Type` for nullable parameters/returns (not `Type|null` — PHP 8.1 compat)
+- Use `array` type hint (not generic `mixed`) when array structure is known
+- Document complex array shapes in docblock `@param` when type hint is insufficient
+
+### PHP Version Compatibility
+- **Minimum: PHP 8.1** — defined in `facturascripts.ini`
+- Do NOT use PHP 8.2+ features (readonly classes, DNF types, `true`/`false`/`null` standalone types)
+- Do NOT use PHP 8.3+ features (`#[Override]`, typed class constants, `json_validate()`)
+- If minimum PHP must change, update `facturascripts.ini` first and document in ADR
+
+### Error Handling
+- No `@` error suppression operator
+- Use explicit `try/catch` for expected failures (API calls, file operations)
+- Let unexpected errors propagate — FacturaScripts handles uncaught exceptions
+- Log errors via `Tools::log()` — never `error_log()` directly
+
+### License Header
+All PHP files must start with the LGPL-3.0 license block matching existing files in the project.
+
+## Reference Files
+- `phpcs.xml` — PHPCS ruleset with PSR-12 + project extras
+- `.php-cs-fixer.php` — PHP CS Fixer config (PSR-12, short arrays, single quotes)
+- `facturascripts.ini` — min PHP version declaration

--- a/.agents/usability-accessibility/SKILL.md
+++ b/.agents/usability-accessibility/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: usability-accessibility
+description: Usability and WCAG 2.1 AA accessibility for AiScan modal UI. ARIA attributes, keyboard navigation, focus management, color contrast, screen reader support, form validation feedback.
+---
+
+# Usability & Accessibility — AiScan UI Guidelines
+
+## Target Standard
+
+**WCAG 2.1 Level AA** — all new and modified UI must meet this baseline.
+
+## Modal Accessibility
+
+The AiScan scanning modal is the primary UI surface. Requirements:
+
+### ARIA Attributes
+```html
+<div class="modal" role="dialog" aria-modal="true" aria-labelledby="aiscan-modal-title">
+  <h5 id="aiscan-modal-title">Escanear Factura</h5>
+  ...
+</div>
+```
+
+### Focus Management
+- On modal open: move focus to the first interactive element (file input or close button)
+- **Focus trap**: Tab key cycles within modal — never escapes to background content
+- On modal close: return focus to the button that opened it
+- Use `tabindex="-1"` on non-interactive containers that receive programmatic focus
+
+### Keyboard Navigation
+| Key | Action |
+|---|---|
+| `Escape` | Close modal |
+| `Enter` | Activate primary action button |
+| `Tab` / `Shift+Tab` | Navigate between interactive elements |
+| Arrow keys | Navigate within radio groups, select menus |
+
+## Wizard Steps
+
+- Mark current step with `aria-current="step"`
+- Announce step changes with `aria-live="polite"` region
+- Previous/Next buttons clearly labeled (not just arrows)
+- Disabled nav buttons use `aria-disabled="true"` + `tabindex="-1"`
+
+## Async Status Feedback
+
+AI analysis takes seconds — user must know what's happening:
+
+```html
+<div aria-live="polite" aria-atomic="true" class="aiscan-status">
+  Analizando documento... <!-- screen readers announce changes -->
+</div>
+```
+
+- Use `aria-live="polite"` for non-urgent updates (analysis progress)
+- Use `aria-live="assertive"` for errors only
+- Include a visible spinner/progress indicator (not just text)
+
+## Confidence Indicators
+
+Extracted data includes confidence scores. Display rules:
+
+- **Never use color alone** — always pair with text or icon
+  - Good: green checkmark + "Alta confianza"
+  - Bad: just a green dot
+- Minimum contrast: text on colored background must meet 4.5:1 ratio
+- Provide tooltip/title with numeric confidence value
+
+## Forms & Validation
+
+### Labels
+- Every `<input>`, `<select>`, `<textarea>` must have an associated `<label>`
+- Use `for="id"` attribute — not wrapping `<label>` (FS convention)
+- Placeholder text is NOT a substitute for a label
+
+### Error Messages
+```html
+<input id="invoice-number" aria-describedby="invoice-number-error" aria-invalid="true">
+<div id="invoice-number-error" class="text-danger" role="alert">
+  Numero de factura requerido
+</div>
+```
+
+- Link errors to inputs via `aria-describedby`
+- Set `aria-invalid="true"` on invalid fields
+- Error messages must be visible (not just color change on border)
+
+## File Upload
+
+- Drag-and-drop area must have a keyboard-accessible alternative (upload button)
+- Drop area: `role="button"` with `tabindex="0"` and `keydown` handler for Enter/Space
+- Announce successful upload: "Archivo subido: factura.pdf"
+- File type restrictions shown visually AND in `accept` attribute
+
+## Split-Pane Layout
+
+The modal uses a 55/45 split (preview left, data right):
+
+- **Tab order**: left pane (document preview) → right pane (extracted data) — logical reading order
+- Draggable divider must be keyboard-accessible (`role="separator"`, arrow keys resize)
+- On mobile (<768px): stack vertically, preview on top
+
+## Tables (Line Items)
+
+```html
+<table class="table" aria-label="Lineas de factura">
+  <thead>
+    <tr><th scope="col">Descripcion</th><th scope="col">Cantidad</th>...</tr>
+  </thead>
+  ...
+</table>
+```
+
+- Use `<th scope="col">` for column headers
+- Editable cells: use `<input>` inside `<td>`, each with label (visible or `aria-label`)
+- Add/remove row buttons: descriptive labels ("Eliminar linea 3")
+
+## Color & Contrast
+
+- **Text on background**: minimum 4.5:1 contrast ratio
+- **UI components** (buttons, inputs, icons): minimum 3:1
+- **Do not convey information by color alone** — always pair with shape, text, or pattern
+- Test with browser DevTools accessibility audit
+
+## Reference Files
+- `Assets/JS/aiscan.js` — UI event handling and DOM manipulation
+- `Assets/CSS/aiscan.css` — Modal, split-pane, and form styling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md – Canonical Agent Instructions
+# AGENTS.md — Canonical Agent Instructions
 
 This is the authoritative instruction file for all coding agents working in this repository.
 All other agent files (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`) refer here.
@@ -9,11 +9,24 @@ All other agent files (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.m
 
 **AiScan** is a FacturaScripts plugin that scans supplier invoices using AI (OpenAI, Google Gemini,
 Mistral, or any OpenAI-compatible endpoint) and maps the extracted data into a purchase invoice.
+Compatibility: **FacturaScripts 2025+**, **PHP 8.1+**, **PSR-12**.
 
-- Plugin name: `AiScan`
-- Compatibility: **FacturaScripts 2025+**, **PHP 8.1+**
-- PSR-12 coding standard (enforced by PHPCS and PHP CS Fixer)
-- Tests live in `Test/main/` and are copied into a FacturaScripts checkout to run
+---
+
+## Agent Skills
+
+Detailed instructions are organized by domain in `.agents/`. Load the relevant skill for your task:
+
+| Skill | When to activate |
+|---|---|
+| [php-expert](.agents/php-expert/SKILL.md) | Writing or reviewing PHP code, fixing lint violations |
+| [javascript-expert](.agents/javascript-expert/SKILL.md) | Working with JS files in Assets/JS/ or Test/js/ |
+| [facturascripts-plugin](.agents/facturascripts-plugin/SKILL.md) | Controllers, extensions, models, XMLViews, Init.php |
+| [usability-accessibility](.agents/usability-accessibility/SKILL.md) | Modal UI, forms, keyboard navigation, ARIA |
+| [devops-testing](.agents/devops-testing/SKILL.md) | Docker, CI, tests, Makefile, packaging |
+| [ai-generative](.agents/ai-generative/SKILL.md) | AI providers, extraction prompts, schema validation |
+| [bootstrap-jquery-design](.agents/bootstrap-jquery-design/SKILL.md) | CSS, Bootstrap components, jQuery UI patterns |
+| [documentation-adr](.agents/documentation-adr/SKILL.md) | ADRs, changelog, README/QUICKSTART updates |
 
 ---
 
@@ -25,27 +38,12 @@ Inspect these files before making assumptions:
 |---|---|
 | `facturascripts.ini` | Plugin name, version, min FacturaScripts version, min PHP |
 | `phpcs.xml` | PHPCS ruleset (PSR-12 + extras, 120-char line limit) |
-| `.php-cs-fixer.php` | PHP CS Fixer config (PSR-12, short arrays, single quotes…) |
+| `.php-cs-fixer.php` | PHP CS Fixer config (PSR-12, short arrays, single quotes) |
 | `Makefile` | All development commands |
-| `.github/workflows/ci.yml` | CI pipeline (Docker lint+test, then PHP matrix 8.1–8.4) |
+| `.github/workflows/ci.yml` | CI pipeline (Docker lint+test, then PHP matrix 8.1-8.4) |
 | `Test/main/` | Unit tests |
 | `Lib/` | Core business logic (matchers, mappers, services) |
-
----
-
-## Coding Rules
-
-- Follow **PSR-12**; max line length **120 characters**
-- Use **short array syntax** (`[]` not `array()`)
-- Use **single quotes** for strings unless interpolation is needed
-- No unused imports; imports ordered alphabetically
-- Forbidden function aliases: `sizeof` → `count`, `delete` → `unset`, `print` → `echo`
-- Preserve FacturaScripts 2025 / PHP 8.1 compatibility — do not use PHP 8.2+ features unless the
-  minimum PHP version in `facturascripts.ini` is updated
-- Keep changes **minimal and focused** — avoid unrelated refactors
-- **Preserve existing behavior** unless the task explicitly requires a behavior change
-- Update tests when changing behavior or covered code paths
-- Keep `README.md` / `QUICKSTART.md` in sync when behavior visible to users changes
+| `docs/adr/` | Architecture Decision Records |
 
 ---
 
@@ -61,23 +59,6 @@ make test     # PHPUnit – all tests must pass
 
 All three require Docker (`make upd` starts the container automatically).
 
-- `make format` uses `friendsofphp/php-cs-fixer` with `.php-cs-fixer.php`
-- `make lint` uses `squizlabs/php_codesniffer` with `phpcs.xml`
-- `make test` copies `Test/main/*` into the container's `Test/Plugins/` and runs PHPUnit
-
-`phpcbf` (PHPCS auto-fixer) is available inside the container but **`make format` is the canonical
-formatting step** — use `make format` first, then `make lint` to verify.
-
----
-
-## Testing Rules
-
-- Tests live in `Test/main/`
-- `make test` installs PHPUnit inside the container if absent, copies the test files, then runs them
-- Do **not** leave failing tests
-- Do **not** remove or skip tests to make the suite pass — fix the underlying issue
-- When adding a new class or changing a public method, add or update the corresponding test
-
 ---
 
 ## Definition of Done
@@ -89,5 +70,6 @@ Before considering a change complete:
 - [ ] `make test` reports **zero failures and zero errors**
 - [ ] No warnings left in output
 - [ ] Behavior is preserved (or intentionally changed and documented)
-- [ ] CI is expected to pass (lint job + PHP matrix 8.1–8.4)
+- [ ] CI is expected to pass (lint job + PHP matrix 8.1-8.4)
 - [ ] Packaging exclusions in `Makefile` updated if new non-distributable files were added
+- [ ] ADR created if an architectural decision was made (see `docs/adr/`)

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,9 @@ package:
 		-x "*README.md" \
 		-x "*Test/*" \
 		-x "*tests/*" \
-		-x "*vendor/*"
+		-x "*vendor/*" \
+		-x "*.agents/*" \
+		-x "*docs/*"
 	@echo "Restoring version in facturascripts.ini..."
 	$(SED_INPLACE) 's/^\(version[[:space:]]*=[[:space:]]*\).*$$/\11.0/' facturascripts.ini
 	@echo "Package created: dist/AiScan-$(VERSION).zip"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to AiScan will be documented in this file.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+
+## [Unreleased]
+
+### Added
+
+- Agent skills architecture in `.agents/` with 8 specialized skills (ADR-0001)
+- ADR framework in `docs/adr/` for tracking architectural decisions
+- This changelog

--- a/docs/adr/0000-adr-template.md
+++ b/docs/adr/0000-adr-template.md
@@ -1,0 +1,34 @@
+# ADR-0000: [Titulo de la Decision]
+
+## Status
+
+[Proposed | Accepted | Deprecated | Superseded by ADR-NNNN]
+
+## Date
+
+YYYY-MM-DD
+
+## Context
+
+Cual es el problema o necesidad que motiva esta decision?
+Incluye restricciones, requisitos y fuerzas en juego.
+
+## Decision
+
+Que se ha decidido hacer y por que?
+Se especifico sobre lo que se hara.
+
+## Consequences
+
+### Positive
+
+- Beneficio 1
+- Beneficio 2
+
+### Negative
+
+- Coste o riesgo 1
+
+### Neutral
+
+- Implicacion sin valoracion clara

--- a/docs/adr/0001-adopt-agent-skills-architecture.md
+++ b/docs/adr/0001-adopt-agent-skills-architecture.md
@@ -1,0 +1,69 @@
+# ADR-0001: Adoptar arquitectura de skills para instrucciones de agentes
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-02
+
+## Context
+
+El proyecto tenia un unico archivo `AGENTS.md` monolitico (93 lineas) que se cargaba completo
+en el contexto de cualquier agente de IA, independientemente de la tarea. Esto supone:
+
+- **Coste de contexto innecesario**: un agente trabajando en CSS cargaba reglas de PHP y viceversa.
+- **Dificultad de mantenimiento**: todas las instrucciones en un solo archivo sin separacion de
+  responsabilidades.
+- **No hay carga progresiva**: sin forma de cargar solo las instrucciones relevantes para la tarea.
+
+Las especificaciones [agents.md](https://agents.md/) y [agentskills.io](https://agentskills.io/)
+definen un patron de skills con carga progresiva: nombre + descripcion para descubrimiento
+(~100 tokens), body completo solo al activar (<5000 tokens).
+
+## Decision
+
+Dividir `AGENTS.md` en 8 skills especializados en `.agents/`, siguiendo la especificacion
+SKILL.md de agentskills.io:
+
+| Skill | Responsabilidad |
+|---|---|
+| `php-expert` | Estandares PHP, PSR-12, reglas phpcs/fixer |
+| `javascript-expert` | Patrones JS, UMD/IIFE, jQuery, tests Node |
+| `facturascripts-plugin` | Arquitectura de plugins FS, controllers, extensions |
+| `usability-accessibility` | WCAG 2.1 AA, ARIA, navegacion por teclado |
+| `devops-testing` | Docker, CI/CD, PHPUnit, make commands |
+| `ai-generative` | Providers IA, prompts, esquema extraccion |
+| `bootstrap-jquery-design` | Bootstrap 5, jQuery UI, patrones de modal |
+| `documentation-adr` | ADRs, changelog, sincronizacion docs |
+
+`AGENTS.md` se simplifica a un indice ligero (~50 lineas) que mantiene solo:
+- Identidad del proyecto
+- Tabla de skills con descripcion y trigger
+- Workflow de validacion (make format/lint/test)
+- Definition of Done
+
+Adicionalmente se establece un framework de ADRs en `docs/adr/` y un changelog en
+`docs/CHANGELOG.md` para documentar decisiones arquitectonicas.
+
+## Consequences
+
+### Positive
+
+- Los agentes cargan solo las instrucciones relevantes para su tarea
+- Cada skill es mantenible de forma independiente
+- Facilita la incorporacion de nuevos expertos sin inflar AGENTS.md
+- Las decisiones arquitectonicas quedan documentadas en ADRs
+- Compatible con multiples herramientas de IA (Claude, Gemini, Copilot)
+
+### Negative
+
+- Mas archivos que mantener (14 nuevos archivos)
+- Los agentes que no soportan la especificacion SKILL.md solo veran el AGENTS.md simplificado
+- Requiere disciplina para crear ADRs en cada decision significativa
+
+### Neutral
+
+- CLAUDE.md, GEMINI.md y copilot-instructions.md no requieren cambios (siguen referenciando AGENTS.md)
+- `.agents/` y `docs/` se excluyen del ZIP de distribucion


### PR DESCRIPTION
## Summary

- Split monolithic `AGENTS.md` (93 lines) into 8 specialized skills in `.agents/` following the [agentskills.io](https://agentskills.io/) SKILL.md specification for progressive context loading
- Added ADR framework in `docs/adr/` with template and first ADR documenting this restructuring
- Added `docs/CHANGELOG.md` in Keep a Changelog format
- Simplified `AGENTS.md` to a lightweight index (~75 lines) referencing skills
- Updated `Makefile` to exclude `.agents/` and `docs/` from distribution ZIP

### Skills created

| Skill | Domain |
|---|---|
| `php-expert` | PSR-12, phpcs/fixer rules, PHP 8.1 compat |
| `javascript-expert` | UMD/IIFE patterns, jQuery, Node --test |
| `facturascripts-plugin` | Controllers, Extensions, Models, XMLView, Init lifecycle |
| `usability-accessibility` | WCAG 2.1 AA, ARIA, keyboard nav, focus management |
| `devops-testing` | Docker, Makefile, PHPUnit, CI matrix PHP 8.1-8.4 |
| `ai-generative` | ProviderInterface, extraction flow, schema validation |
| `bootstrap-jquery-design` | BS5 modal, split-pane, wizard, CSS scoping |
| `documentation-adr` | ADR process, changelog, README/QUICKSTART sync |

## Test plan

- [ ] No PHP changes — `make format`, `make lint`, `make test` unaffected
- [ ] Verify all 8 `.agents/*/SKILL.md` have valid YAML frontmatter
- [ ] Verify `AGENTS.md` references all skills with working links
- [ ] Verify `Makefile` package target excludes `.agents/` and `docs/`
- [ ] Verify `CLAUDE.md`, `GEMINI.md`, `copilot-instructions.md` still work (no changes needed)