### PR TITLE
fix: CI restart loop, product persistence, received status & cache buster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,15 @@ jobs:
       - name: Checkout plugin
         uses: actions/checkout@v6
 
-      - name: Remove plugin mount from docker-compose.yml
+      - name: Remove plugin mount and plugin-dependent env vars from docker-compose.yml
         run: |
           # In CI we don't mount the plugin directory to avoid permission issues
           # Instead we copy the files after the container is running
           sed -i '/\.\/:/d' docker-compose.yml
+          # Remove env vars that reference plugin files (they don't exist yet)
+          sed -i '/FS_SEED_FILE/d' docker-compose.yml
+          sed -i '/POST_CONFIGURE_COMMANDS/d' docker-compose.yml
+          sed -i '/php84.*setup-aiscan\.php/d' docker-compose.yml
 
       - name: Wait for services to be ready
         run: |
@@ -31,14 +35,22 @@ jobs:
           timeout=120
           elapsed=0
           while [ $elapsed -lt $timeout ]; do
-            if docker compose ps | grep -q "healthy"; then
-              echo "✅ Services are healthy"
+            STATUS=$(docker compose ps facturascripts --format '{{.Status}}' 2>/dev/null || true)
+            if echo "$STATUS" | grep -qi "up"; then
+              echo "✅ facturascripts container is up: $STATUS"
               break
             fi
-            echo "⏳ Waiting for services... ($elapsed/$timeout seconds)"
+            echo "⏳ Waiting for facturascripts... status=$STATUS ($elapsed/$timeout seconds)"
             sleep 5
             elapsed=$((elapsed + 5))
           done
+
+          if [ $elapsed -ge $timeout ]; then
+            echo "❌ Timeout waiting for facturascripts container"
+            docker compose ps
+            docker compose logs facturascripts | tail -50
+            exit 1
+          fi
 
           echo "Waiting for FacturaScripts to initialize..."
           sleep 15

--- a/Controller/AiScanInvoice.php
+++ b/Controller/AiScanInvoice.php
@@ -137,8 +137,19 @@ class AiScanInvoice extends Controller
     private function loadPageAssets(): void
     {
         $route = Tools::config('route');
-        AssetManager::addCss($route . '/Plugins/AiScan/Assets/CSS/aiscan.css');
-        AssetManager::addJs($route . '/Plugins/AiScan/Assets/JS/aiscan-workflow.js');
+        $v = '?v=' . $this->getPluginVersion();
+        AssetManager::addCss($route . '/Plugins/AiScan/Assets/CSS/aiscan.css' . $v);
+        AssetManager::addJs($route . '/Plugins/AiScan/Assets/JS/aiscan-workflow.js' . $v);
+    }
+
+    private function getPluginVersion(): string
+    {
+        $iniPath = FS_FOLDER . '/Plugins/AiScan/facturascripts.ini';
+        if (file_exists($iniPath)) {
+            $ini = parse_ini_file($iniPath);
+            return $ini['version'] ?? '0';
+        }
+        return '0';
     }
 
     private function handleUpload(): void

--- a/Lib/InvoiceMapper.php
+++ b/Lib/InvoiceMapper.php
@@ -22,8 +22,8 @@ namespace FacturaScripts\Plugins\AiScan\Lib;
 
 use FacturaScripts\Core\Lib\Calculator;
 use FacturaScripts\Core\Tools;
-use FacturaScripts\Dinamic\Model\Almacen;
 use FacturaScripts\Core\Where;
+use FacturaScripts\Dinamic\Model\Almacen;
 use FacturaScripts\Dinamic\Model\Divisa;
 use FacturaScripts\Dinamic\Model\EstadoDocumento;
 use FacturaScripts\Dinamic\Model\FacturaProveedor;
@@ -296,5 +296,4 @@ class InvoiceMapper
             return;
         }
     }
-
 }

--- a/Lib/InvoiceMapper.php
+++ b/Lib/InvoiceMapper.php
@@ -23,7 +23,9 @@ namespace FacturaScripts\Plugins\AiScan\Lib;
 use FacturaScripts\Core\Lib\Calculator;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Model\Almacen;
+use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Model\Divisa;
+use FacturaScripts\Dinamic\Model\EstadoDocumento;
 use FacturaScripts\Dinamic\Model\FacturaProveedor;
 use FacturaScripts\Dinamic\Model\Proveedor;
 use FacturaScripts\Plugins\AiScan\Model\AiScanSupplierProduct;
@@ -126,6 +128,8 @@ class InvoiceMapper
 
             $this->attachmentService->attachTemporaryFile($invoice, $extractedData['_upload'] ?? []);
 
+            $this->setReceivedStatus($invoice);
+
             $result['success'] = true;
             $result['invoice_id'] = $invoice->idfactura;
         } catch (\Exception $e) {
@@ -154,7 +158,9 @@ class InvoiceMapper
         $invoiceLines = [];
 
         foreach ($preparedLines as $lineData) {
-            $reference = $this->productMatcher->findReference($lineData);
+            $reference = !empty($lineData['referencia'])
+                ? $lineData['referencia']
+                : $this->productMatcher->findReference($lineData);
             $line = $reference ? $invoice->getNewProductLine($reference) : $invoice->getNewLine();
             $desc = $lineData['description'] ?? $lineData['descripcion'] ?? $line->descripcion;
             $line->descripcion = trim((string) $desc);
@@ -276,4 +282,19 @@ class InvoiceMapper
         $subtotal = (float) ($invoiceData['subtotal'] ?? $invoiceData['total'] ?? 0);
         return $subtotal > 0 ? $subtotal : (float) ($invoiceData['total'] ?? 0);
     }
+
+    private function setReceivedStatus(FacturaProveedor $invoice): void
+    {
+        $status = new EstadoDocumento();
+        $where = [
+            Where::column('tipodoc', 'FacturaProveedor'),
+            Where::column('nombre', 'Recibida'),
+        ];
+        foreach ($status->all($where, [], 0, 1) as $received) {
+            $invoice->idestado = $received->idestado;
+            $invoice->save();
+            return;
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

- **CI fix**: The Docker container was stuck in a restart loop because `FS_SEED_FILE` and `POST_CONFIGURE_COMMANDS` env vars referenced plugin files that don't exist before the mount is set up. Now those vars are removed in CI, and the wait logic checks the `facturascripts` container specifically with proper timeout/error handling.
- **Product in invoice lines**: When the user selects a product (referencia) in the UI, it is now used directly instead of being ignored and falling back to fuzzy matching via ProductMatcher.
- **Invoice status**: Imported invoices are now set to "Recibida" status instead of the default "Boceto".
- **Asset cache buster**: CSS and JS assets now include `?v=<plugin_version>` to force browser cache refresh on plugin updates.

## Test plan

- [ ] Verify CI passes (Docker container starts without restart loop)
- [ ] Import an invoice with a product selected in a line — confirm the product persists after save
- [ ] Confirm imported invoice shows "Recibida" status, not "Boceto"
- [ ] Update plugin version in `facturascripts.ini` and verify CSS/JS URLs include the new version