### PR TITLE
fix: handle tax-inclusive prices on simplified receipts (closes #30)

### DIFF
--- a/Lib/ExtractionService.php
+++ b/Lib/ExtractionService.php
@@ -200,6 +200,17 @@ Field-specific rules:
   If cantidad > 1, divide the base amount by cantidad.
   Never return 0 or null if the line has a visible monetary amount.
   NEVER confuse "Dto" / "Descuento" / "Discount" columns with the unit price.
+  TAX-INCLUSIVE PRICES (simplified receipts / tickets):
+    Spanish "FACTURA SIMPLIFICADA", "TICKET", "RECIBO SIMPLIFICADO", or any
+    document showing "IGIC INCLUIDO", "IVA INCLUIDO", "Impuestos incluidos",
+    "TAX INCLUDED" prints unit prices that ALREADY INCLUDE tax.
+    In that case pvpunitario MUST be the tax-EXCLUSIVE value:
+        pvpunitario = displayed_price / (1 + tax_rate/100)
+    Example: ticket shows "Precio 5,70" with IGIC 7% included →
+    pvpunitario = 5.70 / 1.07 = 5.327103.
+    Additional signal: when the "Importe" column values multiplied by quantity
+    sum to the TOTAL (not to the "Base imponible"), the displayed prices are
+    tax-inclusive and you MUST convert them.
   MANDATORY VERIFICATION for each line:
   1. Read the line "Total" or "Importe" column value.
   2. Compute: cantidad * pvpunitario * (1 - dtopor/100).

--- a/Lib/SchemaValidator.php
+++ b/Lib/SchemaValidator.php
@@ -255,6 +255,12 @@ class SchemaValidator
             }
             unset($line);
 
+            // Detect tax-inclusive line prices typical of "factura simplificada"
+            // / tickets marked "IGIC INCLUIDO" or "IVA INCLUIDO" and convert
+            // each unit price to tax-exclusive so downstream calculation does
+            // not double-count the tax.
+            $this->fixTaxInclusiveLinePrices($data);
+
             // Distribute withholding to lines if invoice has it but lines don't
             $withholding = (float) ($data['invoice']['withholding_amount'] ?? 0);
             if ($withholding > 0 && !empty($data['lines'])) {
@@ -291,6 +297,81 @@ class SchemaValidator
         }
 
         return $data;
+    }
+
+    /**
+     * Convert tax-inclusive line unit prices to tax-exclusive when the
+     * extracted lines clearly carry post-tax amounts (typical for Spanish
+     * "factura simplificada" / tickets with "IGIC INCLUIDO" or
+     * "IVA INCLUIDO" footers).
+     *
+     * Detection: if the sum of (cantidad × pvpunitario × (1 − dtopor/100))
+     * across all lines matches the invoice total — and clearly differs from
+     * the subtotal — the unit prices already include tax. We then divide
+     * each pvpunitario by (1 + iva/100). Lines without a positive iva are
+     * left untouched.
+     */
+    private function fixTaxInclusiveLinePrices(array &$data): void
+    {
+        if (empty($data['lines']) || !is_array($data['lines'])) {
+            return;
+        }
+
+        $invoice = is_array($data['invoice'] ?? null) ? $data['invoice'] : [];
+        $subtotal = (float) ($invoice['subtotal'] ?? 0);
+        $total = (float) ($invoice['total'] ?? 0);
+        $taxAmount = (float) ($invoice['tax_amount'] ?? 0);
+
+        if ($subtotal <= 0 || $total <= 0 || $taxAmount <= 0) {
+            return;
+        }
+
+        // No tax: subtotal == total, nothing to convert.
+        if (abs($total - $subtotal) < 0.01) {
+            return;
+        }
+
+        $lineSum = 0.0;
+        $anyTaxedLine = false;
+        foreach ($data['lines'] as $line) {
+            $qty = (float) ($line['cantidad'] ?? 1);
+            $price = (float) ($line['pvpunitario'] ?? 0);
+            $discount = (float) ($line['dtopor'] ?? 0);
+            $lineSum += $qty * $price * (1 - $discount / 100);
+            if ((float) ($line['iva'] ?? 0) > 0) {
+                $anyTaxedLine = true;
+            }
+        }
+
+        if ($lineSum <= 0 || !$anyTaxedLine) {
+            return;
+        }
+
+        $tolerance = max(0.02, $total * 0.005);
+        $diffToSubtotal = abs($lineSum - $subtotal);
+        $diffToTotal = abs($lineSum - $total);
+
+        // Only treat as tax-inclusive when the line sum is meaningfully closer
+        // to the total than to the subtotal.
+        if ($diffToTotal >= $tolerance || $diffToTotal >= $diffToSubtotal) {
+            return;
+        }
+
+        foreach ($data['lines'] as &$line) {
+            $iva = (float) ($line['iva'] ?? 0);
+            if ($iva <= 0) {
+                continue;
+            }
+            $line['pvpunitario'] = round((float) ($line['pvpunitario'] ?? 0) / (1 + $iva / 100), 6);
+            if (isset($line['pvptotal'])) {
+                $qty = (float) ($line['cantidad'] ?? 1);
+                $discount = (float) ($line['dtopor'] ?? 0);
+                $line['pvptotal'] = round($line['pvpunitario'] * $qty * (1 - $discount / 100), 2);
+            }
+        }
+        unset($line);
+
+        $data['_tax_inclusive_lines_converted'] = true;
     }
 
     private function normalizeDate(string $date): string

--- a/Test/fixtures/responses/F-2026-026-igic-included.json
+++ b/Test/fixtures/responses/F-2026-026-igic-included.json
@@ -1,0 +1,65 @@
+{
+    "document_type": "receipt",
+    "supplier": {
+        "name": "Cafetería Maracaná",
+        "tax_id": "B38764833",
+        "email": null,
+        "phone": "922663078",
+        "website": null,
+        "address": "Avda. Los Menceyes 337, La Cuesta, 38320 San Cristóbal de La Laguna"
+    },
+    "customer": {
+        "name": null,
+        "tax_id": null,
+        "address": null
+    },
+    "invoice": {
+        "number": "T-058755/26",
+        "issue_date": "2026-05-07",
+        "due_date": null,
+        "currency": "EUR",
+        "subtotal": 18.04,
+        "tax_amount": 1.26,
+        "withholding_amount": 0,
+        "total": 19.30,
+        "summary": "Reina Pepida y Vitaminado Super (IGIC incluido)",
+        "payment_terms": null
+    },
+    "taxes": [
+        {
+            "name": "IGIC",
+            "rate": 7,
+            "base": 18.04,
+            "amount": 1.26
+        }
+    ],
+    "lines": [
+        {
+            "description": "REINA PEPIDA",
+            "quantity": 2,
+            "unit_price": 5.70,
+            "discount": 0,
+            "tax_rate": 7,
+            "line_total": 11.40,
+            "sku": "80"
+        },
+        {
+            "description": "VITAMINADO SUPER",
+            "quantity": 2,
+            "unit_price": 3.95,
+            "discount": 0,
+            "tax_rate": 7,
+            "line_total": 7.90,
+            "sku": "581"
+        }
+    ],
+    "confidence": {
+        "supplier_name": 0.92,
+        "supplier_tax_id": 0.97,
+        "invoice_number": 0.60,
+        "issue_date": 0.95,
+        "total": 0.98,
+        "lines": 0.90
+    },
+    "warnings": []
+}

--- a/Test/main/InvoicePipelineTest.php
+++ b/Test/main/InvoicePipelineTest.php
@@ -72,6 +72,7 @@ final class InvoicePipelineTest extends TestCase
             'two-lines-same-tax' => ['F-2024-012'],
             'two-lines-mixed-tax-with-retention' => ['F-2024-014'],
             'simple-1-line-low-amount' => ['F-2024-021'],
+            'simplified-receipt-igic-included' => ['F-2026-026-igic-included'],
         ];
     }
 
@@ -459,5 +460,66 @@ final class InvoicePipelineTest extends TestCase
         $normalized = $this->validator->normalize($raw);
 
         $this->assertSame('EUR', $normalized['invoice']['currency']);
+    }
+
+    // ── IGIC-included simplified receipt (issue #30) ────────────────────
+
+    public function testSimplifiedReceiptIgicIncludedConvertsLinesToTaxExclusive(): void
+    {
+        $raw = self::loadFixture('F-2026-026-igic-included');
+
+        // Raw fixture matches what the AI returns for the Cafetería Maracaná
+        // ticket: sum of (qty × unit_price) equals the TOTAL (19.30), not the
+        // SUBTOTAL (18.04), because the displayed prices include IGIC.
+        $rawLineSum = 0.0;
+        foreach ($raw['lines'] as $line) {
+            $rawLineSum += $line['quantity'] * $line['unit_price'];
+        }
+        $this->assertEqualsWithDelta(
+            $raw['invoice']['total'],
+            $rawLineSum,
+            0.02,
+            'Pre-normalization line sum should match the invoice total'
+        );
+
+        $normalized = $this->validator->normalize($raw);
+
+        $this->assertTrue(
+            $normalized['_tax_inclusive_lines_converted'] ?? false,
+            'Normalization should detect tax-inclusive prices on this receipt'
+        );
+
+        $normalizedLineSum = 0.0;
+        foreach ($normalized['lines'] as $line) {
+            $normalizedLineSum += $line['cantidad'] * $line['pvpunitario'];
+        }
+        $this->assertEqualsWithDelta(
+            $normalized['invoice']['subtotal'],
+            $normalizedLineSum,
+            0.02,
+            'After conversion line sum should match the invoice subtotal'
+        );
+    }
+
+    public function testSimplifiedReceiptArithmeticAfterConversion(): void
+    {
+        $raw = self::loadFixture('F-2026-026-igic-included');
+        $normalized = $this->validator->normalize($raw);
+
+        $linesSubtotal = 0.0;
+        $linesTax = 0.0;
+        foreach ($normalized['lines'] as $line) {
+            $base = $line['cantidad'] * $line['pvpunitario']
+                * (1 - ($line['dtopor'] ?? 0) / 100);
+            $linesSubtotal += $base;
+            $linesTax += $base * ($line['iva'] / 100);
+        }
+
+        $this->assertEqualsWithDelta(
+            $normalized['invoice']['total'],
+            $linesSubtotal + $linesTax,
+            0.02,
+            'Recomputing total from converted lines must match the receipt total'
+        );
     }
 }

--- a/Test/main/SchemaValidatorTest.php
+++ b/Test/main/SchemaValidatorTest.php
@@ -563,6 +563,216 @@ final class SchemaValidatorTest extends TestCase
         );
     }
 
+    // ── tax-inclusive line price normalization ─────────────
+
+    public function testNormalizeConvertsIgicIncludedLinePricesToTaxExclusive(): void
+    {
+        // Cafetería Maracaná (IGIC INCLUIDO) — see issue #30.
+        // Lines come with tax-inclusive unit prices (5.70 and 3.95) so the
+        // sum of (qty × price) equals the total (19.30), not the subtotal
+        // (18.04). After normalization unit prices must become tax-exclusive.
+        $data = $this->validator->normalize([
+            'invoice' => [
+                'number' => 'T-058755/26',
+                'issue_date' => '2026-05-07',
+                'subtotal' => 18.04,
+                'tax_amount' => 1.26,
+                'total' => 19.30,
+            ],
+            'lines' => [
+                [
+                    'description' => 'REINA PEPIDA',
+                    'quantity' => 2,
+                    'unit_price' => 5.70,
+                    'tax_rate' => 7,
+                    'line_total' => 11.40,
+                ],
+                [
+                    'description' => 'VITAMINADO SUPER',
+                    'quantity' => 2,
+                    'unit_price' => 3.95,
+                    'tax_rate' => 7,
+                    'line_total' => 7.90,
+                ],
+            ],
+        ]);
+
+        $this->assertTrue(
+            $data['_tax_inclusive_lines_converted'] ?? false,
+            'Tax-inclusive prices should have been detected and flagged'
+        );
+
+        $expected = [5.70 / 1.07, 3.95 / 1.07];
+        foreach ($data['lines'] as $index => $line) {
+            $this->assertEqualsWithDelta(
+                $expected[$index],
+                $line['pvpunitario'],
+                0.0001,
+                "Line {$index} pvpunitario should be tax-exclusive"
+            );
+        }
+
+        $lineSum = 0.0;
+        foreach ($data['lines'] as $line) {
+            $lineSum += $line['cantidad'] * $line['pvpunitario'];
+        }
+        $this->assertEqualsWithDelta(18.04, $lineSum, 0.02);
+    }
+
+    public function testNormalizeLeavesTaxExclusiveLinePricesUntouched(): void
+    {
+        // Line sum (350) matches subtotal (350), not total (374.50).
+        // Prices are correctly tax-exclusive; no conversion must happen.
+        $data = $this->validator->normalize([
+            'invoice' => [
+                'number' => 'INV-001',
+                'issue_date' => '2026-01-01',
+                'subtotal' => 350.0,
+                'tax_amount' => 24.50,
+                'total' => 374.50,
+            ],
+            'lines' => [
+                [
+                    'description' => 'Gestión redes sociales',
+                    'quantity' => 1,
+                    'unit_price' => 350.0,
+                    'tax_rate' => 7,
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($data['_tax_inclusive_lines_converted'] ?? false);
+        $this->assertEqualsWithDelta(350.0, $data['lines'][0]['pvpunitario'], 0.01);
+    }
+
+    public function testNormalizeSkipsConversionWhenInvoiceHasNoTax(): void
+    {
+        // subtotal == total, no tax breakdown → never convert.
+        $data = $this->validator->normalize([
+            'invoice' => [
+                'number' => 'INV-001',
+                'issue_date' => '2026-01-01',
+                'subtotal' => 100.0,
+                'tax_amount' => 0,
+                'total' => 100.0,
+            ],
+            'lines' => [
+                [
+                    'description' => 'Servicio exento',
+                    'quantity' => 1,
+                    'unit_price' => 100.0,
+                    'tax_rate' => 0,
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($data['_tax_inclusive_lines_converted'] ?? false);
+        $this->assertEqualsWithDelta(100.0, $data['lines'][0]['pvpunitario'], 0.01);
+    }
+
+    public function testNormalizeConvertsMixedTaxRatesWhenInclusive(): void
+    {
+        // Two lines: 10 € at 21% and 5 € at 10% (both tax-inclusive).
+        // Subtotal = 10/1.21 + 5/1.10 = 8.2645 + 4.5455 = 12.8100
+        // Tax     = 10 - 8.2645 + 5 - 4.5455 = 2.190
+        // Total   = 15.00 (= sum of inclusive line prices)
+        $data = $this->validator->normalize([
+            'invoice' => [
+                'number' => 'INV-001',
+                'issue_date' => '2026-01-01',
+                'subtotal' => 12.81,
+                'tax_amount' => 2.19,
+                'total' => 15.00,
+            ],
+            'lines' => [
+                [
+                    'description' => 'Producto A',
+                    'quantity' => 1,
+                    'unit_price' => 10.0,
+                    'tax_rate' => 21,
+                ],
+                [
+                    'description' => 'Producto B',
+                    'quantity' => 1,
+                    'unit_price' => 5.0,
+                    'tax_rate' => 10,
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($data['_tax_inclusive_lines_converted'] ?? false);
+        $this->assertEqualsWithDelta(10.0 / 1.21, $data['lines'][0]['pvpunitario'], 0.0001);
+        $this->assertEqualsWithDelta(5.0 / 1.10, $data['lines'][1]['pvpunitario'], 0.0001);
+    }
+
+    public function testNormalizeAdjustsLineTotalWhenConverting(): void
+    {
+        $data = $this->validator->normalize([
+            'invoice' => [
+                'number' => 'INV-001',
+                'issue_date' => '2026-01-01',
+                'subtotal' => 18.04,
+                'tax_amount' => 1.26,
+                'total' => 19.30,
+            ],
+            'lines' => [
+                [
+                    'description' => 'REINA PEPIDA',
+                    'quantity' => 2,
+                    'unit_price' => 5.70,
+                    'tax_rate' => 7,
+                    'line_total' => 11.40,
+                ],
+                [
+                    'description' => 'VITAMINADO SUPER',
+                    'quantity' => 2,
+                    'unit_price' => 3.95,
+                    'tax_rate' => 7,
+                    'line_total' => 7.90,
+                ],
+            ],
+        ]);
+
+        $this->assertEqualsWithDelta(
+            round(2 * (5.70 / 1.07), 2),
+            $data['lines'][0]['pvptotal'],
+            0.01
+        );
+        $this->assertEqualsWithDelta(
+            round(2 * (3.95 / 1.07), 2),
+            $data['lines'][1]['pvptotal'],
+            0.01
+        );
+    }
+
+    public function testNormalizeRespectsDiscountWhenDetectingInclusive(): void
+    {
+        // Line: qty 1, price 21.40 with 50% discount and 7% IGIC included.
+        // Net post-discount inclusive: 10.70 → should match total 10.70.
+        // Tax-exclusive expected: 21.40 / 1.07 = 20.0
+        $data = $this->validator->normalize([
+            'invoice' => [
+                'number' => 'INV-001',
+                'issue_date' => '2026-01-01',
+                'subtotal' => 10.0,
+                'tax_amount' => 0.70,
+                'total' => 10.70,
+            ],
+            'lines' => [
+                [
+                    'description' => 'Discounted item',
+                    'quantity' => 1,
+                    'unit_price' => 21.40,
+                    'discount' => 50,
+                    'tax_rate' => 7,
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($data['_tax_inclusive_lines_converted'] ?? false);
+        $this->assertEqualsWithDelta(20.0, $data['lines'][0]['pvpunitario'], 0.001);
+    }
+
     // ── isMultiInvoice() ────────────────────────────────────
 
     public function testIsMultiInvoiceReturnsTrueForMultipleInvoices(): void


### PR DESCRIPTION
## Summary

- Detect tax-inclusive line prices in `SchemaValidator::normalize()` and convert them to tax-exclusive so `Calculator::calculate()` does not re-apply IGIC/IVA on top.
- Extend the extraction prompt to recognize "FACTURA SIMPLIFICADA", "TICKET", "IGIC INCLUIDO", "IVA INCLUIDO" and similar markers, instructing the AI to convert `pvpunitario` to tax-exclusive at extraction time.
- Add a JSON fixture (`F-2026-026-igic-included.json`) modelled on the reporter's Cafetería Maracaná ticket plus six SchemaValidator unit tests and two pipeline tests.

Closes #30.

## Root cause

The prompt defines `lines[].pvpunitario` as "Unit price BEFORE discount and BEFORE tax", but Spanish simplified receipts (tickets) display tax-inclusive prices. With the Maracaná ticket the AI returned `pvpunitario = 5,70` and `3,95` (the printed values), so FacturaScripts computed `Σ qty × price × (1 + 7%) = 20,65 €` instead of the printed `19,30 €`.

## Fix

Two complementary layers:

1. **Prompt update** in `Lib/ExtractionService.php` — instructs the model to recognize tax-inclusive markers and divide the displayed price by `(1 + tax_rate/100)`.
2. **Defensive normalization** in `Lib/SchemaValidator.php` — when `Σ qty × pvpunitario × (1 − dtopor/100)` matches the invoice **total** within tolerance (and clearly differs from the **subtotal**), each line's `pvpunitario` is divided by `(1 + iva/100)` and `pvptotal` recomputed. Sets a `_tax_inclusive_lines_converted` debug flag.

The defensive layer is the load-bearing one — it catches cases where the AI misses the prompt instruction.

## Test plan

- [x] `make format` — 0 fixes
- [x] `make lint` — 31/31 files clean
- [x] `make test` — 165/165 tests, 522 assertions pass
- [x] New tests:
  - `testNormalizeConvertsIgicIncludedLinePricesToTaxExclusive`
  - `testNormalizeLeavesTaxExclusiveLinePricesUntouched`
  - `testNormalizeSkipsConversionWhenInvoiceHasNoTax`
  - `testNormalizeConvertsMixedTaxRatesWhenInclusive`
  - `testNormalizeAdjustsLineTotalWhenConverting`
  - `testNormalizeRespectsDiscountWhenDetectingInclusive`
  - `testSimplifiedReceiptIgicIncludedConvertsLinesToTaxExclusive`
  - `testSimplifiedReceiptArithmeticAfterConversion`
- [x] Existing fixtures (`F-2024-004`, `-011`, `-012`, `-014`, `-021`) remain unaffected — no regressions in arithmetic-consistency or line-totals-match-subtotal tests.