### PR TITLE
ci: add PHP 8.5 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     services:
       mysql:


### PR DESCRIPTION
## What

Add **PHP 8.5** to the CI test matrix (`.github/workflows/ci.yml`), alongside 8.1–8.4.

## Why

Reported in #49: a user on **PHP 8.5** / FacturaScripts 2025.81 hit a fatal
`Class "...\Extension\Controller\EditFacturaProveedor" not found in Init.php:32`.

Investigation (see issue for full write-up): this is **not** a PHP 8.5
language incompatibility. It was caused by `Init::init()` calling
`loadExtension(new Extension\Controller\EditFacturaProveedor())` on a plugin
build where that class wasn't loadable. Commit `4a7f6c5` ("refactor: remove
extension buttons from invoice screens") already removed those `loadExtension`
calls and the `Extension/` classes, so `init()` is now empty and the crash
cannot occur on `main`. The reporter was running a pre-`4a7f6c5` release.

To back this up empirically, every plugin PHP file parses cleanly under PHP
8.5.6 (`php -l`). This PR locks that in by adding 8.5 to CI so the suite runs
against the latest PHP going forward.

## Note

If the `test` job fails on 8.5 because upstream FacturaScripts' `composer
install` caps the PHP version, we may need `--ignore-platform-reqs` on the 8.5
leg — will confirm once CI runs.

Closes #49
