### PR TITLE
docs: guía E2E y referencias a PHP 8.5 en AGENTS.md (+ helper de smoke test)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Inspect these files before making assumptions:
 | `phpcs.xml` | PHPCS ruleset (PSR-12 + extras, 120-char line limit) |
 | `.php-cs-fixer.php` | PHP CS Fixer config (PSR-12, short arrays, single quotes) |
 | `Makefile` | All development commands |
-| `.github/workflows/ci.yml` | CI pipeline (Docker lint+test, then PHP matrix 8.1-8.4) |
+| `.github/workflows/ci.yml` | CI pipeline (Docker lint+test, then PHP matrix 8.1-8.5) |
 | `Test/main/` | Unit tests |
 | `Lib/` | Core business logic (matchers, mappers, services) |
 | `docs/adr/` | Architecture Decision Records |
@@ -61,6 +61,47 @@ All three require Docker (`make upd` starts the container automatically).
 
 ---
 
+## End-to-end validation (real AI extraction → purchase invoice)
+
+Unit tests cover the pipeline with recorded JSON responses (`Test/fixtures/responses/`)
+but never call a real provider. To validate the whole flow (upload → AI extraction →
+review → import) against a live model, the dev `docker-compose.yml` already enables the
+plugin, seeds demo data (`blueprint.json`) and reads provider keys from the host
+environment.
+
+1. Export a provider key on the host **before** `make up`, e.g. `export GEMINI_API_KEY=…`
+   (the container's `docker/setup-aiscan.php` writes it into the AiScan settings on boot).
+2. `make up` — starts FacturaScripts + MariaDB. Open the app and log in (`admin`/`admin`).
+   - Port: `http://localhost:8080` by default; the committed `docker-compose.override.yml`
+     remaps it to **`http://localhost:18080`** (check `docker compose ps`).
+3. Select the provider in **Compras → AiScan** ("Proveedor de IA"), or set it once:
+   `default_provider=gemini` in the `AiScan` Settings (then clear the cache).
+4. Drop a sample invoice from `Test/fixtures/` (PDF/JPG/PNG) on the upload zone, pick
+   **Factura detallada**, analyze, review and import. Verify:
+   - a `FacturaProveedor` is created with the right supplier, number and total;
+   - the source file is attached (**Archivos** tab) and the image/PDF opens via the
+     private `myft` URL (this is the JPG/JPEG path hardened in the attachment flow);
+   - with **"Actualizar stock y datos de compra"** enabled, stock moves for linked
+     products and per-line warnings (localized) are shown for the rest;
+   - the keyboard navigation works on the review-screen product autocomplete
+     (↑/↓ to highlight, Enter/Tab to select, Esc to close).
+
+`Test/fixtures/` ships anonymized sample invoices (e.g. `F-2025-004…007`) covering IRPF
+retention, IGIC, mixed/`suplido` lines and a 0%-IGIC image; reuse them and add new ones
+(plus a matching `responses/*.json` wired into `InvoicePipelineTest`) when covering a new
+case. `Test/` is `export-ignore`d, so fixtures never ship in the release ZIP.
+
+For a non-interactive smoke test of the extraction→map→import path against the live
+provider, run `Test/e2e-smoke.php` inside the container (it iterates the fixtures and
+reports the created invoice, attachment and warnings):
+
+```bash
+docker compose cp Test/e2e-smoke.php facturascripts:/tmp/ \
+  && docker compose exec -T facturascripts php84 /tmp/e2e-smoke.php
+```
+
+---
+
 ## Definition of Done
 
 Before considering a change complete:
@@ -70,6 +111,6 @@ Before considering a change complete:
 - [ ] `make test` reports **zero failures and zero errors**
 - [ ] No warnings left in output
 - [ ] Behavior is preserved (or intentionally changed and documented)
-- [ ] CI is expected to pass (lint job + PHP matrix 8.1-8.4)
+- [ ] CI is expected to pass (lint job + PHP matrix 8.1-8.5)
 - [ ] Packaging exclusions in `Makefile` updated if new non-distributable files were added
 - [ ] ADR created if an architectural decision was made (see `docs/adr/`)

--- a/Test/e2e-smoke.php
+++ b/Test/e2e-smoke.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * This file is part of AiScan plugin for FacturaScripts.
+ * Copyright (C) 2026 Ernesto Serrano <info@ernesto.es>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Non-interactive end-to-end smoke test: runs the real upload -> AI extraction ->
+ * supplier match -> map -> import path against the configured AI provider, using
+ * the sample invoices in Test/fixtures/. Intended to be run INSIDE the dev
+ * container against a throwaway database (it creates suppliers and invoices).
+ *
+ * Usage (from the plugin root):
+ *   docker compose cp Test/e2e-smoke.php facturascripts:/tmp/
+ *   docker compose exec -T facturascripts php84 /tmp/e2e-smoke.php [fixture] [provider]
+ *
+ * Examples:
+ *   php84 /tmp/e2e-smoke.php                 # all default fixtures, default provider
+ *   php84 /tmp/e2e-smoke.php F-2025-007.jpg  # one fixture
+ *   php84 /tmp/e2e-smoke.php F-2025-004.pdf gemini
+ */
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+define('FS_FOLDER', '/var/www/html');
+require_once FS_FOLDER . '/vendor/autoload.php';
+require_once FS_FOLDER . '/config.php';
+
+use FacturaScripts\Core\Kernel;
+use FacturaScripts\Core\Where;
+use FacturaScripts\Plugins\AiScan\Lib\ExtractionService;
+use FacturaScripts\Plugins\AiScan\Lib\InvoiceMapper;
+use FacturaScripts\Plugins\AiScan\Lib\SupplierMatcher;
+
+Kernel::init();
+
+$fixturesDir = FS_FOLDER . '/Plugins/AiScan/Test/fixtures';
+$tmpDir = FS_FOLDER . '/MyFiles/aiscan_tmp';
+@mkdir($tmpDir, 0777, true);
+
+$mimeByExt = [
+    'pdf' => 'application/pdf',
+    'jpg' => 'image/jpeg',
+    'jpeg' => 'image/jpeg',
+    'png' => 'image/png',
+    'webp' => 'image/webp',
+];
+
+$argFixture = $argv[1] ?? '';
+$provider = $argv[2] ?? null; // null = plugin default provider
+
+$cases = $argFixture !== ''
+    ? [$argFixture]
+    : ['F-2025-007.jpg', 'F-2025-004.pdf', 'F-2025-005.pdf', 'F-2025-006.pdf'];
+
+$failures = 0;
+foreach ($cases as $file) {
+    echo "\n================= {$file} =================\n";
+    $ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
+    $mime = $mimeByExt[$ext] ?? 'application/octet-stream';
+
+    $source = $fixturesDir . '/' . $file;
+    if (!is_file($source)) {
+        echo "MISSING fixture: {$source}\n";
+        $failures++;
+        continue;
+    }
+
+    // Stage the file like handleUpload does (keep a real extension).
+    $tmpName = 'aiscan_e2e_' . preg_replace('/[^a-z0-9]/i', '_', pathinfo($file, PATHINFO_FILENAME)) . '.' . $ext;
+    copy($source, $tmpDir . '/' . $tmpName);
+
+    try {
+        $extracted = (new ExtractionService())->extractFromFile($tmpDir . '/' . $tmpName, $mime, $provider, 'lines');
+    } catch (\Throwable $e) {
+        echo 'EXTRACTION ERROR: ' . $e->getMessage() . "\n";
+        $failures++;
+        continue;
+    }
+
+    $supplier = $extracted['supplier']['name'] ?? '(none)';
+    $total = $extracted['invoice']['total'] ?? '(none)';
+    $lines = count($extracted['lines'] ?? []);
+    echo "EXTRACT: supplier='{$supplier}' total={$total} lines={$lines}\n";
+
+    $match = (new SupplierMatcher())->findMatch($extracted['supplier'] ?? []);
+    $extracted['supplier']['match_status'] = $match['match_status'];
+    if (!empty($match['supplier'])) {
+        $extracted['supplier']['matched_supplier_id'] = $match['supplier']->codproveedor;
+    } else {
+        // Simulate the UI choosing to create the supplier when not matched.
+        $extracted['supplier']['create_if_missing'] = true;
+    }
+
+    // Attach the uploaded source file (exercises the attachment flow).
+    $extracted['_upload'] = ['tmp_file' => $tmpName, 'original_name' => $file];
+
+    $result = (new InvoiceMapper())->mapToInvoice($extracted, null, 'lines', true);
+    if (!$result['success']) {
+        echo 'IMPORT FAILED: ' . implode('; ', $result['errors']) . "\n";
+        $failures++;
+        continue;
+    }
+
+    $invoice = new \FacturaScripts\Dinamic\Model\FacturaProveedor();
+    $invoice->loadFromCode($result['invoice_id']);
+    echo "IMPORT OK: {$invoice->codigo} proveedor='{$invoice->nombre}' total={$invoice->total}\n";
+    foreach ($result['warnings'] as $warning) {
+        echo "  warning: {$warning}\n";
+    }
+
+    $relations = (new \FacturaScripts\Dinamic\Model\AttachedFileRelation())->all([
+        Where::eq('model', 'FacturaProveedor'),
+        Where::eq('modelid', $invoice->idfactura),
+    ]);
+    foreach ($relations as $relation) {
+        $attached = new \FacturaScripts\Dinamic\Model\AttachedFile();
+        $attached->loadFromCode($relation->idfile);
+        $state = is_file(FS_FOLDER . '/' . $attached->path) ? 'exists' : 'MISSING';
+        echo "  attachment: {$attached->path} ({$attached->mimetype}, {$state})\n";
+    }
+}
+
+echo "\n" . ($failures === 0 ? "SMOKE OK\n" : "SMOKE FAILURES: {$failures}\n");
+exit($failures === 0 ? 0 : 1);

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,6 +17,7 @@
     <exclude-pattern>XMLView/</exclude-pattern>
     <exclude-pattern>Test/bootstrap.php</exclude-pattern>
     <exclude-pattern>Test/install-plugins.php</exclude-pattern>
+    <exclude-pattern>Test/e2e-smoke.php</exclude-pattern>
 
     <!-- Include PSR-12 standard -->
     <rule ref="PSR12"/>


### PR DESCRIPTION
Probé a fondo **en local con `make up` y Chrome + extracción real de Gemini** todos los PRs mezclados hoy (#27, #29, #46, #48, #41, #31, #52). **No encontré errores funcionales** — todo funciona end-to-end. Lo que sí faltaba/estaba desactualizado es la documentación, que es lo que corrige este PR.

## Cambios

- **AGENTS.md — guía de validación E2E**: documenta el flujo real (subir → extracción IA → revisión → importar) con `make up`, puerto (`8080`, o `18080` por el `docker-compose.override.yml`), login, selección de proveedor de IA y uso de las fixtures, igual que la receta de ScheduledMail. Así cualquier agente puede reproducir la verificación contra un proveedor real.
- **`Test/e2e-smoke.php`**: helper no interactivo que recorre las fixtures y ejecuta extracción + mapeo + import, reportando factura/adjunto/avisos. Pensado para correr dentro del contenedor de desarrollo.
- **Corrección de referencias desactualizadas**: la matriz de CI pasó a `8.1-8.5` (tras añadir 8.5), pero AGENTS.md seguía diciendo `8.1-8.4` en dos sitios.
- **PHPCS**: se excluye el helper de dev del lint, como ya se hace con `Test/bootstrap.php` e `install-plugins.php`.

## Verificación realizada (resumen)

- #46 stock: stock 0→5 con producto vinculado; `ProductoProveedor` con precio actualizado; avisos (localizados) para líneas sin producto.
- #29 adjuntos: imagen JPG importada se sirve y renderiza por URL privada `myft`, con extensión correcta en carpeta fechada estándar.
- #48 forma de pago: selector en la UI y en revisión; `codpago` aplicado a la factura.
- #27 teclado: en navegador real, el autocompletar abre, resalta la primera sugerencia y **Enter** la selecciona (fija la referencia).
- #31 IGIC incluido: detección y conversión de precios correcta.
- #41: avisos en español. #52: Gemini extrae las fixtures (imagen y PDF) correctamente.
