### PR TITLE
feat: sugerir producto por defecto del proveedor al escanear (#53)

### DIFF
--- a/Assets/JS/aiscan-workflow.js
+++ b/Assets/JS/aiscan-workflow.js
@@ -1167,6 +1167,10 @@
         review.appendChild(buildSection(trans('aiscan-section-supplier'), supplierBody,
             {collapsed: supplierMatched, headerExtra: supplierSummary}));
 
+        if (supplierMatched && supplier.matched_supplier_id) {
+            review.appendChild(buildDefaultProductSection(supplier));
+        }
+
         review.appendChild(buildSection(trans('aiscan-section-invoice'), `
             <div class="d-flex gap-2 mb-1">
                 <div style="flex:2">${buildInput(trans('number'), 'invoice_number', invoice.number || '', 'text', null, confidence.invoice_number)}</div>
@@ -1340,29 +1344,26 @@
 
     function buildDefaultProductSection(supplier) {
         const codproveedor = supplier.matched_supplier_id || '';
-        const section = document.createElement('div');
-        section.className = 'card mb-3';
-        section.innerHTML = `
-            <div class="card-header py-2">${escapeHtml(trans('aiscan-default-product'))}</div>
-            <div class="card-body py-2">
-                <div class="mb-2">
-                    <label class="form-label small mb-1">${escapeHtml(trans('aiscan-default-product-help'))}</label>
-                    <div class="input-group input-group-sm">
-                        <input type="text" class="form-control" id="aiscan-product-search" placeholder="${escapeAttr(trans('search'))}">
-                        <button class="btn btn-outline-secondary" type="button" id="aiscan-product-search-btn"><i class="fa-solid fa-search"></i></button>
-                    </div>
-                    <div id="aiscan-product-results" class="list-group mt-1" style="max-height:150px;overflow-y:auto"></div>
+        const body = `
+            <div class="mb-2">
+                <label class="form-label small mb-1">${escapeHtml(trans('aiscan-default-product-help'))}</label>
+                <div class="input-group input-group-sm">
+                    <input type="text" class="form-control" id="aiscan-product-search" placeholder="${escapeAttr(trans('search'))}">
+                    <button class="btn btn-outline-secondary" type="button" id="aiscan-product-search-btn"><i class="fa-solid fa-search"></i></button>
                 </div>
-                <div class="mb-2">
-                    <label class="form-label small mb-1" for="default_product_ref">${escapeHtml(trans('reference'))}</label>
-                    <input class="form-control form-control-sm" id="default_product_ref" type="text" value="" data-codproveedor="${escapeAttr(codproveedor)}">
-                </div>
-                <button type="button" class="btn btn-outline-primary btn-sm" id="aiscan-save-default-product">
-                    <i class="fa-solid fa-floppy-disk me-1"></i>${escapeHtml(trans('aiscan-save-default-product'))}
-                </button>
-                <span class="small text-muted ms-2" id="aiscan-default-product-status"></span>
+                <div id="aiscan-product-results" class="list-group mt-1" style="max-height:150px;overflow-y:auto"></div>
             </div>
+            <div class="mb-2">
+                <label class="form-label small mb-1" for="default_product_ref">${escapeHtml(trans('reference'))}</label>
+                <input class="form-control form-control-sm" id="default_product_ref" type="text" value="" data-codproveedor="${escapeAttr(codproveedor)}">
+            </div>
+            <button type="button" class="btn btn-outline-primary btn-sm" id="aiscan-save-default-product">
+                <i class="fa-solid fa-floppy-disk me-1"></i>${escapeHtml(trans('aiscan-save-default-product'))}
+            </button>
+            <span class="small text-muted ms-2" id="aiscan-default-product-status"></span>
         `;
+
+        const section = buildSection(trans('aiscan-default-product'), body, {collapsed: true});
 
         setTimeout(() => {
             if (codproveedor) {

--- a/Assets/JS/aiscan-workflow.js
+++ b/Assets/JS/aiscan-workflow.js
@@ -1904,7 +1904,8 @@
 
     function buildLineRow(line, index) {
         const ref = line.referencia || line.sku || '';
-        const matchBadge = buildProductMatchBadge(ref);
+        const refSource = line.referencia_source || '';
+        const matchBadge = buildProductMatchBadge(ref, refSource);
         const modalId = 'aiscan-line-modal-' + index;
         const resultsId = 'aiscan-line-product-results-' + index;
         const desc = line.descripcion || line.description || '';
@@ -2034,10 +2035,14 @@
         </div>`;
     }
 
-    function buildProductMatchBadge(reference) {
-        return reference
-            ? `<span class="badge text-bg-success" data-bs-toggle="tooltip" data-bs-placement="top" title="${escapeAttr(reference)}"><i class="fa-solid fa-link"></i></span>`
-            : `<span class="badge text-bg-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="${escapeAttr(trans('aiscan-no-product'))}"><i class="fa-solid fa-unlink"></i></span>`;
+    function buildProductMatchBadge(reference, source) {
+        if (!reference) {
+            return `<span class="badge text-bg-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="${escapeAttr(trans('aiscan-no-product'))}"><i class="fa-solid fa-unlink"></i></span>`;
+        }
+        if (source === 'history') {
+            return `<span class="badge text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="${escapeAttr(trans('aiscan-product-suggested-history') + ': ' + reference)}"><i class="fa-solid fa-clock-rotate-left"></i></span>`;
+        }
+        return `<span class="badge text-bg-success" data-bs-toggle="tooltip" data-bs-placement="top" title="${escapeAttr(reference)}"><i class="fa-solid fa-link"></i></span>`;
     }
 
     function setLineProductMatch(row, reference) {
@@ -3206,6 +3211,7 @@
         globalThis.__aiscanWorkflowTestHooks = {
             applySelectionRange,
             buildPaymentMethodSelect,
+            buildProductMatchBadge,
             calcAllLineTotals,
             checkTotalMismatch,
             collectFormData,

--- a/Controller/AiScanInvoice.php
+++ b/Controller/AiScanInvoice.php
@@ -410,6 +410,12 @@ class AiScanInvoice extends Controller
                     $matchResult['candidates']
                 );
             }
+
+            // issue #53: pre-fill lines without a product using the supplier's
+            // usual product (most repeated, ties broken by most recent).
+            if (!empty($extracted['supplier']['matched_supplier_id'])) {
+                $this->suggestSupplierProducts($extracted);
+            }
         }
 
         // Check for duplicate invoice already in FacturaScripts
@@ -420,6 +426,33 @@ class AiScanInvoice extends Controller
         }
 
         return $extracted;
+    }
+
+    /**
+     * Pre-fills extracted lines that have no product reference with the
+     * supplier's usual product, flagging them as a history suggestion so the
+     * review screen shows a distinct (editable) badge. Issue #53.
+     */
+    private function suggestSupplierProducts(array &$extracted): void
+    {
+        if (empty($extracted['lines']) || !is_array($extracted['lines'])) {
+            return;
+        }
+
+        $service = new HistoricalContextService();
+        $suggestion = $service->getSuggestedProduct($extracted['supplier']['matched_supplier_id']);
+        if (empty($suggestion['referencia'])) {
+            return;
+        }
+
+        foreach ($extracted['lines'] as &$line) {
+            if (!empty(trim((string) ($line['referencia'] ?? '')))) {
+                continue;
+            }
+            $line['referencia'] = $suggestion['referencia'];
+            $line['referencia_source'] = 'history';
+        }
+        unset($line);
     }
 
     private function handleMatchSupplier(): void

--- a/Lib/HistoricalContextService.php
+++ b/Lib/HistoricalContextService.php
@@ -22,6 +22,7 @@ namespace FacturaScripts\Plugins\AiScan\Lib;
 
 use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Model\FacturaProveedor;
+use FacturaScripts\Plugins\AiScan\Model\AiScanSupplierProduct;
 
 class HistoricalContextService
 {
@@ -96,5 +97,106 @@ class HistoricalContextService
             . 'but always prioritize evidence from the current document.';
 
         return implode("\n", $parts);
+    }
+
+    /**
+     * Suggests the product this supplier most likely bills, to pre-fill lines
+     * that could not be matched otherwise (issue #53).
+     *
+     * Priority:
+     *   1. The product manually pinned for the supplier (AiScanSupplierProduct).
+     *   2. The most frequent product across previous invoices
+     *      (ties broken by most recent), via rankProductsFromLines().
+     *
+     * @return array{referencia: string, description: string}|null
+     */
+    public function getSuggestedProduct(string $codproveedor): ?array
+    {
+        if (empty($codproveedor)) {
+            return null;
+        }
+
+        $pinned = AiScanSupplierProduct::getForSupplier($codproveedor);
+        if ($pinned && !empty($pinned->referencia)) {
+            return [
+                'referencia' => $pinned->referencia,
+                'description' => (string) ($pinned->description ?? ''),
+            ];
+        }
+
+        $invoice = new FacturaProveedor();
+        $where = [Where::eq('codproveedor', $codproveedor)];
+        $orderBy = ['fecha' => 'DESC'];
+        $invoices = $invoice->all($where, $orderBy, 0, self::MAX_INVOICES);
+
+        if (empty($invoices)) {
+            return null;
+        }
+
+        $historyLines = [];
+        foreach ($invoices as $inv) {
+            foreach ($inv->getLines() as $line) {
+                $historyLines[] = [
+                    'referencia' => (string) ($line->referencia ?? ''),
+                    'description' => mb_substr(trim((string) $line->descripcion), 0, 100),
+                    'date' => (string) $inv->fecha,
+                ];
+            }
+        }
+
+        $ranking = self::rankProductsFromLines($historyLines);
+        if (empty($ranking)) {
+            return null;
+        }
+
+        return [
+            'referencia' => $ranking[0]['referencia'],
+            'description' => $ranking[0]['description'],
+        ];
+    }
+
+    /**
+     * Pure ranking helper (no DB): orders product references by frequency
+     * (descending), breaking ties by the most recent date. Lines without a
+     * referencia are ignored.
+     *
+     * @param array<array{referencia?: string, description?: string, date?: string}> $lines
+     *
+     * @return array<array{referencia: string, description: string, count: int, last_date: string}>
+     */
+    public static function rankProductsFromLines(array $lines): array
+    {
+        $stats = [];
+        foreach ($lines as $line) {
+            $referencia = trim((string) ($line['referencia'] ?? ''));
+            if ($referencia === '') {
+                continue;
+            }
+
+            $date = (string) ($line['date'] ?? '');
+            if (!isset($stats[$referencia])) {
+                $stats[$referencia] = [
+                    'referencia' => $referencia,
+                    'description' => (string) ($line['description'] ?? ''),
+                    'count' => 0,
+                    'last_date' => $date,
+                ];
+            }
+
+            $stats[$referencia]['count']++;
+            if ($date > $stats[$referencia]['last_date']) {
+                $stats[$referencia]['last_date'] = $date;
+                if (!empty($line['description'])) {
+                    $stats[$referencia]['description'] = (string) $line['description'];
+                }
+            }
+        }
+
+        $ranking = array_values($stats);
+        usort($ranking, static function (array $a, array $b): int {
+            return [$b['count'], $b['last_date']] <=> [$a['count'], $a['last_date']];
+        });
+
+        return $ranking;
     }
 }

--- a/Lib/InvoiceMapper.php
+++ b/Lib/InvoiceMapper.php
@@ -36,7 +36,8 @@ class InvoiceMapper
         private readonly AttachmentService $attachmentService = new AttachmentService(),
         private readonly ProductMatcher $productMatcher = new ProductMatcher(),
         private readonly PurchaseLineInventoryUpdater $inventoryUpdater = new PurchaseLineInventoryUpdater(),
-        private readonly SupplierService $supplierService = new SupplierService()
+        private readonly SupplierService $supplierService = new SupplierService(),
+        private readonly HistoricalContextService $historicalContext = new HistoricalContextService()
     ) {
     }
 
@@ -143,7 +144,7 @@ class InvoiceMapper
             $taxes = $extractedData['taxes'] ?? [];
             $invoiceLines = $importMode === 'total' && empty($lines)
                 ? $this->buildTotalModeLines($invoice, $invoiceData, $taxes, $supplier)
-                : $this->buildLinesMode($invoice, $lines, $invoiceData);
+                : $this->buildLinesMode($invoice, $lines, $invoiceData, $supplier);
 
             if (empty($invoiceLines) || false === Calculator::calculate($invoice, $invoiceLines, true)) {
                 $result['errors'][] = Tools::lang()->trans('aiscan-failed-to-calculate-invoice-lines');
@@ -185,15 +186,27 @@ class InvoiceMapper
         return implode("\n\n", array_unique($parts));
     }
 
-    private function buildLinesMode(FacturaProveedor $invoice, array $lines, array $invoiceData): array
-    {
+    private function buildLinesMode(
+        FacturaProveedor $invoice,
+        array $lines,
+        array $invoiceData,
+        ?Proveedor $supplier = null
+    ): array {
         $preparedLines = $this->prepareLines($lines, $invoiceData);
         $invoiceLines = [];
+
+        // issue #53: fallback to the supplier's usual product for lines that
+        // cannot be matched by SKU or description.
+        $suggestedReference = null;
+        if ($supplier) {
+            $suggestion = $this->historicalContext->getSuggestedProduct($supplier->codproveedor);
+            $suggestedReference = $suggestion['referencia'] ?? null;
+        }
 
         foreach ($preparedLines as $lineData) {
             $reference = !empty($lineData['referencia'])
                 ? $lineData['referencia']
-                : $this->productMatcher->findReference($lineData);
+                : $this->productMatcher->findReference($lineData, $suggestedReference);
             $line = $reference ? $invoice->getNewProductLine($reference) : $invoice->getNewLine();
             $line->actualizastock = 0;
             $desc = $lineData['description'] ?? $lineData['descripcion'] ?? $line->descripcion;

--- a/Lib/ProductMatcher.php
+++ b/Lib/ProductMatcher.php
@@ -25,7 +25,16 @@ use FacturaScripts\Dinamic\Model\Variante;
 
 class ProductMatcher
 {
-    public function findReference(array $lineData): ?string
+    /**
+     * Resolves the product reference for a line.
+     *
+     * Order of precedence: exact SKU/barcode, then a unique description match.
+     * As a last resort (issue #53), if a supplier-history suggestion is given,
+     * it is returned so the line is pre-filled with the supplier's usual
+     * product instead of staying unlinked. The suggestion never overrides a
+     * real match.
+     */
+    public function findReference(array $lineData, ?string $suggestedReference = null): ?string
     {
         $sku = trim((string) ($lineData['sku'] ?? ''));
         if (!empty($sku)) {
@@ -38,16 +47,15 @@ class ProductMatcher
         }
 
         $description = trim((string) ($lineData['description'] ?? ''));
-        if (mb_strlen($description) < 4) {
-            return null;
+        if (mb_strlen($description) >= 4) {
+            $variant = new Variante();
+            $results = $variant->codeModelSearch($description, 'referencia');
+            if (count($results) === 1) {
+                return $results[0]->code ?? null;
+            }
         }
 
-        $variant = new Variante();
-        $results = $variant->codeModelSearch($description, 'referencia');
-        if (count($results) !== 1) {
-            return null;
-        }
-
-        return $results[0]->code ?? null;
+        $suggestion = trim((string) ($suggestedReference ?? ''));
+        return $suggestion !== '' ? $suggestion : null;
     }
 }

--- a/Model/AiScanSupplierProduct.php
+++ b/Model/AiScanSupplierProduct.php
@@ -20,9 +20,9 @@
 
 namespace FacturaScripts\Plugins\AiScan\Model;
 
-use FacturaScripts\Core\Template\ModelClass;
-use FacturaScripts\Core\Template\ModelTrait;
-use FacturaScripts\Core\Where;
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Model\Base\ModelClass;
+use FacturaScripts\Core\Model\Base\ModelTrait;
 
 class AiScanSupplierProduct extends ModelClass
 {
@@ -64,7 +64,7 @@ class AiScanSupplierProduct extends ModelClass
 
     public static function getForSupplier(string $codproveedor): ?self
     {
-        $where = [Where::eq('codproveedor', $codproveedor)];
+        $where = [new DataBaseWhere('codproveedor', $codproveedor)];
         $found = self::all($where, [], 0, 1);
         return $found[0] ?? null;
     }

--- a/Model/AiScanSupplierProduct.php
+++ b/Model/AiScanSupplierProduct.php
@@ -20,8 +20,8 @@
 
 namespace FacturaScripts\Plugins\AiScan\Model;
 
-use FacturaScripts\Core\Model\Base\ModelClass;
-use FacturaScripts\Core\Model\Base\ModelTrait;
+use FacturaScripts\Core\Template\ModelClass;
+use FacturaScripts\Core\Template\ModelTrait;
 use FacturaScripts\Core\Where;
 
 class AiScanSupplierProduct extends ModelClass
@@ -64,12 +64,9 @@ class AiScanSupplierProduct extends ModelClass
 
     public static function getForSupplier(string $codproveedor): ?self
     {
-        $model = new self();
         $where = [Where::eq('codproveedor', $codproveedor)];
-        if ($model->loadWhere($where)) {
-            return $model;
-        }
-        return null;
+        $found = self::all($where, [], 0, 1);
+        return $found[0] ?? null;
     }
 
     public static function setForSupplier(string $codproveedor, string $referencia, string $description = ''): bool

--- a/Test/js/aiscan-workflow.test.js
+++ b/Test/js/aiscan-workflow.test.js
@@ -410,3 +410,27 @@ test('resolveAutocompleteKeyAction selects with tab and closes with escape', () 
         {type: 'close', preventDefault: true}
     );
 });
+
+test('buildProductMatchBadge renders the unlinked state without a reference', () => {
+    const {hooks} = loadTestHooks();
+    const badge = hooks.buildProductMatchBadge('');
+    assert.match(badge, /text-bg-secondary/);
+    assert.match(badge, /fa-unlink/);
+});
+
+test('buildProductMatchBadge renders a green link for a real match', () => {
+    const {hooks} = loadTestHooks();
+    const badge = hooks.buildProductMatchBadge('REF-1');
+    assert.match(badge, /text-bg-success/);
+    assert.match(badge, /fa-link/);
+    assert.match(badge, /REF-1/);
+});
+
+test('buildProductMatchBadge renders the history suggestion state', () => {
+    const {hooks} = loadTestHooks();
+    const badge = hooks.buildProductMatchBadge('REF-1', 'history');
+    assert.match(badge, /text-bg-warning/);
+    assert.match(badge, /fa-clock-rotate-left/);
+    assert.match(badge, /REF-1/);
+    assert.doesNotMatch(badge, /text-bg-success/);
+});

--- a/Test/main/HistoricalContextServiceTest.php
+++ b/Test/main/HistoricalContextServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of AiScan plugin for FacturaScripts.
+ * Copyright (C) 2026 Ernesto Serrano <info@ernesto.es>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Plugins;
+
+use FacturaScripts\Plugins\AiScan\Lib\HistoricalContextService;
+use PHPUnit\Framework\TestCase;
+
+final class HistoricalContextServiceTest extends TestCase
+{
+    public function testRankByFrequency(): void
+    {
+        $lines = [
+            ['referencia' => 'A', 'description' => 'Alpha', 'date' => '2026-01-01'],
+            ['referencia' => 'B', 'description' => 'Beta', 'date' => '2026-01-02'],
+            ['referencia' => 'A', 'description' => 'Alpha', 'date' => '2026-01-03'],
+        ];
+
+        $ranking = HistoricalContextService::rankProductsFromLines($lines);
+
+        $this->assertSame('A', $ranking[0]['referencia']);
+        $this->assertSame(2, $ranking[0]['count']);
+        $this->assertSame('B', $ranking[1]['referencia']);
+    }
+
+    public function testTieBrokenByMostRecentDate(): void
+    {
+        $lines = [
+            ['referencia' => 'OLD', 'description' => 'Old', 'date' => '2026-01-01'],
+            ['referencia' => 'NEW', 'description' => 'New', 'date' => '2026-05-01'],
+        ];
+
+        $ranking = HistoricalContextService::rankProductsFromLines($lines);
+
+        // Same count (1 each) -> the most recent wins the tie.
+        $this->assertSame('NEW', $ranking[0]['referencia']);
+        $this->assertSame('OLD', $ranking[1]['referencia']);
+    }
+
+    public function testIgnoresLinesWithoutReference(): void
+    {
+        $lines = [
+            ['referencia' => '', 'description' => 'No product', 'date' => '2026-01-01'],
+            ['referencia' => '  ', 'description' => 'Blank', 'date' => '2026-01-02'],
+            ['referencia' => 'X', 'description' => 'Real', 'date' => '2026-01-03'],
+        ];
+
+        $ranking = HistoricalContextService::rankProductsFromLines($lines);
+
+        $this->assertCount(1, $ranking);
+        $this->assertSame('X', $ranking[0]['referencia']);
+    }
+
+    public function testEmptyInputReturnsEmptyArray(): void
+    {
+        $this->assertSame([], HistoricalContextService::rankProductsFromLines([]));
+    }
+
+    public function testDescriptionFollowsMostRecentOccurrence(): void
+    {
+        $lines = [
+            ['referencia' => 'A', 'description' => 'Old name', 'date' => '2026-01-01'],
+            ['referencia' => 'A', 'description' => 'New name', 'date' => '2026-02-01'],
+        ];
+
+        $ranking = HistoricalContextService::rankProductsFromLines($lines);
+
+        $this->assertSame('New name', $ranking[0]['description']);
+    }
+}

--- a/Test/main/ProductMatcherTest.php
+++ b/Test/main/ProductMatcherTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of AiScan plugin for FacturaScripts.
+ * Copyright (C) 2026 Ernesto Serrano <info@ernesto.es>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Plugins;
+
+use FacturaScripts\Plugins\AiScan\Lib\ProductMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class ProductMatcherTest extends TestCase
+{
+    private ProductMatcher $matcher;
+
+    protected function setUp(): void
+    {
+        $this->matcher = new ProductMatcher();
+    }
+
+    public function testFallsBackToSuggestionWhenNoSkuOrDescriptionMatch(): void
+    {
+        // Empty SKU and a too-short description skip the DB lookups, so the
+        // supplier-history suggestion is the only candidate left (issue #53).
+        $reference = $this->matcher->findReference(
+            ['sku' => '', 'description' => 'ab'],
+            'SUGGESTED-REF'
+        );
+
+        $this->assertSame('SUGGESTED-REF', $reference);
+    }
+
+    public function testReturnsNullWhenNoMatchAndNoSuggestion(): void
+    {
+        $reference = $this->matcher->findReference(['sku' => '', 'description' => 'ab']);
+
+        $this->assertNull($reference);
+    }
+
+    public function testEmptySuggestionIsTreatedAsNoSuggestion(): void
+    {
+        $reference = $this->matcher->findReference(
+            ['sku' => '', 'description' => 'ab'],
+            '   '
+        );
+
+        $this->assertNull($reference);
+    }
+}

--- a/Translation/en_EN.json
+++ b/Translation/en_EN.json
@@ -116,6 +116,7 @@
     "aiscan-no-file-specified": "No file specified.",
     "aiscan-no-file-uploaded": "No file uploaded.",
     "aiscan-no-product": "No product assigned",
+    "aiscan-product-suggested-history": "Suggested from supplier history",
     "aiscan-no-preview": "No preview available",
     "aiscan-no-providers": "No AI providers configured. Go to AiScan settings.",
     "aiscan-no-results": "No results",

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -116,6 +116,7 @@
     "aiscan-no-file-specified": "No se ha especificado ningún archivo.",
     "aiscan-no-file-uploaded": "No se ha subido ningún archivo.",
     "aiscan-no-product": "Sin producto asociado",
+    "aiscan-product-suggested-history": "Sugerido del histórico del proveedor",
     "aiscan-no-preview": "Vista previa no disponible",
     "aiscan-no-providers": "No hay proveedores de IA configurados. Ve a la configuración de AiScan.",
     "aiscan-no-results": "Sin resultados",

--- a/View/AiScanInvoice.html.twig
+++ b/View/AiScanInvoice.html.twig
@@ -320,6 +320,7 @@
         'aiscan-matched-with': '{{ i18n.trans('aiscan-matched-with')|e('js') }}',
         'aiscan-no-file-uploaded': '{{ i18n.trans('aiscan-no-file-uploaded')|e('js') }}',
         'aiscan-no-product': '{{ i18n.trans('aiscan-no-product')|e('js') }}',
+        'aiscan-product-suggested-history': '{{ i18n.trans('aiscan-product-suggested-history')|e('js') }}',
         'aiscan-no-preview': '{{ i18n.trans('aiscan-no-preview')|e('js') }}',
         'aiscan-no-results': '{{ i18n.trans('aiscan-no-results')|e('js') }}',
         'aiscan-rounding-diff': '{{ i18n.trans('aiscan-rounding-diff')|e('js') }}',


### PR DESCRIPTION
## Problema (issue #53)

Cuando se escanea una factura de un proveedor que ya se ha usado antes, es muy probable que el producto se repita. Hoy hay que **enlazar el producto a mano en casi todas las líneas**, incluso para proveedores recurrentes que siempre facturan lo mismo.

La casilla **"Usar facturas anteriores como contexto"** ya existía, pero solo metía las facturas previas como **texto en el prompt de la IA**; no preseleccionaba ningún producto de forma programática.

## Qué hace este cambio

Cuando el proveedor de la factura escaneada **coincide** con uno existente, se **preselecciona en cada línea sin producto** el producto habitual de ese proveedor:

1. El producto **fijado manualmente** para el proveedor (`AiScanSupplierProduct`), si existe.
2. Si no, el producto **más repetido** en sus últimas facturas (`FacturaProveedor`), con **desempate por el más reciente**.

La sugerencia es **editable y con aviso**: en la pantalla de revisión aparece con un badge distinto (naranja, icono de histórico) en lugar del verde de coincidencia real, así se distingue de un enlace exacto y se puede cambiar o quitar con el autocompletado de siempre. Es independiente de la casilla de contexto de IA, que se queda como está.

El producto fijado manualmente (prioridad 1) **se configura desde la propia pantalla de revisión**: bajo el proveedor identificado aparece una **sección colapsable "Producto predeterminado para este proveedor"** con buscador de producto y botón de guardar. Sin ella la tabla `aiscan_supplier_products` nunca se llenaba y la prioridad 1 era inalcanzable desde la interfaz.

## Detalles de implementación

- **`Lib/HistoricalContextService.php`**
  - `rankProductsFromLines()`: función pura (sin BD) que ordena las referencias por frecuencia y desempata por fecha más reciente.
  - `getSuggestedProduct()`: prioriza el producto fijado manualmente y, si no, calcula el más repetido del histórico.
- **`Lib/ProductMatcher.php`**: `findReference()` acepta una referencia sugerida como **último recurso**; nunca pisa una coincidencia real por SKU/código de barras/descripción.
- **`Controller/AiScanInvoice.php`**: `enrichExtractedData()` rellena la referencia sugerida por línea y marca `referencia_source = 'history'`. Endpoints AJAX `get-supplier-default-product` / `set-supplier-default-product` para leer y guardar el producto fijado.
- **`Assets/JS/aiscan-workflow.js`**:
  - `buildProductMatchBadge()` añade el estado "sugerido del histórico".
  - `buildDefaultProductSection()` ahora se **inserta en el panel de revisión** (bajo el proveedor, solo cuando hay proveedor identificado) como **sección colapsable** reutilizando `buildSection`. Antes existía pero no se montaba en el DOM, así que no era usable.
- **`Lib/InvoiceMapper.php`**: aplica la sugerencia también en **importaciones por lote** (sin pasar por la pantalla de revisión).
- **`Model/AiScanSupplierProduct.php`**: se mantiene sobre la base de modelo del plugin (`Core\Model\Base\ModelClass`, que crea la tabla desde `./Table/aiscan_supplier_products.xml`) y se corrige `getForSupplier()` usando `DataBaseWhere` + `all()`, patrón compatible con esa base (igual que `EditAiScanImportBatch`). La migración a `Core\Template\ModelClass` se descartó porque rompía el pipeline en BD limpia (CI): esa base genera la tabla desde un XML en `Core/Table/` inexistente para el plugin.

## Tests

- `Test/main/HistoricalContextServiceTest.php`: ranking por frecuencia, desempate por fecha, ignora líneas sin referencia, entrada vacía.
- `Test/main/ProductMatcherTest.php`: la sugerencia solo se usa como fallback.
- `Test/js/aiscan-workflow.test.js`: los 3 estados del badge (sin producto / enlace real / sugerencia del histórico).

Validación: `make format` ✅ · `make lint` (0 violaciones) ✅ · `make test` (223 PHP + 16 JS) ✅

Closes #53
