### PR TITLE
fix: infer missing line tax rate from invoice tax breakdown (#61)

### DIFF
--- a/Lib/InvoiceMapper.php
+++ b/Lib/InvoiceMapper.php
@@ -144,7 +144,7 @@ class InvoiceMapper
             $taxes = $extractedData['taxes'] ?? [];
             $invoiceLines = $importMode === 'total' && empty($lines)
                 ? $this->buildTotalModeLines($invoice, $invoiceData, $taxes, $supplier)
-                : $this->buildLinesMode($invoice, $lines, $invoiceData, $supplier);
+                : $this->buildLinesMode($invoice, $lines, $invoiceData, $taxes, $supplier);
 
             if (empty($invoiceLines) || false === Calculator::calculate($invoice, $invoiceLines, true)) {
                 $result['errors'][] = Tools::lang()->trans('aiscan-failed-to-calculate-invoice-lines');
@@ -190,9 +190,10 @@ class InvoiceMapper
         FacturaProveedor $invoice,
         array $lines,
         array $invoiceData,
+        array $taxes = [],
         ?Proveedor $supplier = null
     ): array {
-        $preparedLines = $this->prepareLines($lines, $invoiceData);
+        $preparedLines = $this->prepareLines($lines, $invoiceData, $taxes);
         $invoiceLines = [];
 
         // issue #53: fallback to the supplier's usual product for lines that
@@ -292,10 +293,10 @@ class InvoiceMapper
         return [$line];
     }
 
-    private function prepareLines(array $lines, array $invoiceData): array
+    private function prepareLines(array $lines, array $invoiceData, array $taxes = []): array
     {
         if (!empty($lines)) {
-            return $lines;
+            return $this->inferMissingTaxRate($lines, $invoiceData, $taxes);
         }
 
         return [[
@@ -305,6 +306,72 @@ class InvoiceMapper
             'discount' => 0,
             'tax_rate' => $this->computeTaxRate($invoiceData),
         ]];
+    }
+
+    /**
+     * Issue #61: some AI extractions only report the tax rate in the invoice-level
+     * `taxes` breakdown, leaving it out of the individual lines. Calculator then
+     * books those lines at 0%, so the total looks right but the accounting entry
+     * (asiento) does not reflect the tax. Infer the missing rate from the
+     * breakdown, but only when it is unambiguous: a single tax entry whose
+     * base/amount reconcile with the invoice totals and with the sum of the
+     * lines, and no suplido lines (which are excluded from the taxable base).
+     */
+    private function inferMissingTaxRate(array $lines, array $invoiceData, array $taxes): array
+    {
+        if (count($taxes) !== 1) {
+            return $lines;
+        }
+
+        $tax = $taxes[0];
+        $rate = (float) ($tax['rate'] ?? 0);
+        $base = (float) ($tax['base'] ?? 0);
+        $amount = (float) ($tax['amount'] ?? 0);
+        $tolerance = 0.01;
+
+        if (abs($amount) < 0.001) {
+            return $lines;
+        }
+
+        $subtotal = (float) ($invoiceData['subtotal'] ?? 0);
+        $taxAmount = (float) ($invoiceData['tax_amount'] ?? 0);
+        if (abs($base - $subtotal) > $tolerance || abs($amount - $taxAmount) > $tolerance) {
+            return $lines;
+        }
+
+        $linesSubtotal = 0.0;
+        foreach ($lines as $line) {
+            if (!empty($line['suplido'] ?? false)) {
+                return $lines;
+            }
+            $quantity = (float) ($line['quantity'] ?? $line['cantidad'] ?? 1);
+            $unitPrice = (float) ($line['unit_price'] ?? $line['pvpunitario'] ?? 0);
+            $discount = (float) ($line['discount'] ?? $line['dtopor'] ?? 0);
+            $linesSubtotal += $quantity * $unitPrice * (1 - $discount / 100);
+        }
+
+        if (abs($linesSubtotal - $base) > $tolerance) {
+            return $lines;
+        }
+
+        foreach ($lines as &$line) {
+            if (!$this->lineHasTaxInfo($line)) {
+                $line['tax_rate'] = $rate;
+            }
+        }
+        unset($line);
+
+        return $lines;
+    }
+
+    private function lineHasTaxInfo(array $line): bool
+    {
+        $taxRate = $line['tax_rate'] ?? $line['iva'] ?? null;
+        if ($taxRate !== null && $taxRate !== '') {
+            return true;
+        }
+
+        return !empty($line['codimpuesto'] ?? $line['tax_code'] ?? '');
     }
 
     private function computeTaxRate(array $invoiceData): float

--- a/Test/main/InvoiceMapperTest.php
+++ b/Test/main/InvoiceMapperTest.php
@@ -154,6 +154,44 @@ final class InvoiceMapperTest extends TestCase
         $this->assertEqualsWithDelta(0.0, $result[0]['unit_price'], 0.01);
     }
 
+    // Regression for issue #61: "factura con IGIC que se refleja en el total
+    // pero no en el asiento". The AI extraction reports the 7% IGIC rate only
+    // in the aggregate `taxes` breakdown, not on the line itself. When real
+    // lines are supplied (so prepareLines() would otherwise just pass them
+    // through untouched), it must still infer and attach the correct tax
+    // rate from the `taxes` bucket. Otherwise Calculator books the line at
+    // 0% and the resulting accounting entry (asiento) does not reflect the
+    // IGIC, even though the invoice total (built from top-level fields)
+    // looks correct in the review screen.
+    public function testPrepareLinesInfersTaxRateFromTaxesArrayWhenLineOmitsIt(): void
+    {
+        $lines = [
+            [
+                'description' => 'Factura por tarjetas de visita, rediseño y vinilo.',
+                'quantity' => 1,
+                'unit_price' => 92.55,
+            ],
+        ];
+        $invoiceData = [
+            'subtotal' => 92.55,
+            'tax_amount' => 6.48,
+            'total' => 99.03,
+        ];
+        $taxes = [
+            ['rate' => 7.0, 'base' => 92.55, 'amount' => 6.48],
+        ];
+
+        $result = $this->callPrepareLines($lines, $invoiceData, $taxes);
+
+        $this->assertCount(1, $result);
+        $inferredRate = $result[0]['tax_rate'] ?? $result[0]['iva'] ?? null;
+        $this->assertNotNull(
+            $inferredRate,
+            'prepareLines() should infer a tax rate from the taxes array when the line omits it'
+        );
+        $this->assertEqualsWithDelta(7.0, $inferredRate, 0.01);
+    }
+
     // ── helpers ──────────────────────────────────────────────
 
     private function callBuildNotes(array $invoiceData): string
@@ -163,11 +201,11 @@ final class InvoiceMapperTest extends TestCase
         return $method->invoke($this->mapper, $invoiceData);
     }
 
-    private function callPrepareLines(array $lines, array $invoiceData): array
+    private function callPrepareLines(array $lines, array $invoiceData, array $taxes = []): array
     {
         $method = new \ReflectionMethod(InvoiceMapper::class, 'prepareLines');
         $method->setAccessible(true);
-        return $method->invoke($this->mapper, $lines, $invoiceData);
+        return $method->invoke($this->mapper, $lines, $invoiceData, $taxes);
     }
 
     // ── Payment method validation ───────────────────────────


### PR DESCRIPTION
@AnaLaRama Aquí va la explicación de qué hemos arreglado y cómo probarlo.

## Qué pasaba

En algunas facturas, la IA reconocía correctamente el IGIC/IVA a nivel de
factura (aparecía bien en el total), pero **no lo asignaba a la línea**
del detalle. Esto pasaba cuando la IA solo informaba el tipo de impuesto
en el desglose general (`taxes`) y no en cada línea concreta.

Como la línea se quedaba sin impuesto (0%), FacturaScripts generaba el
asiento contable sin el IGIC, aunque el total de la factura sí lo
mostrara bien. Es decir: total correcto en pantalla, asiento incorrecto.

## Qué se ha arreglado

Ahora, cuando una línea llega sin tipo de impuesto pero la factura tiene
un desglose de impuestos claro y sin ambigüedad, se infiere el tipo y se
aplica a la línea antes de generar el asiento. Solo se hace cuando es
seguro:

- Hay un único tipo de impuesto en el desglose (no aplica si hay varios).
- La base y la cuota de ese impuesto cuadran con el subtotal/impuesto de
  la factura.
- La suma de las líneas cuadra con esa base imponible.
- Ninguna línea es un "suplido".

Si algo de esto no cuadra, se deja el comportamiento actual tal cual (no
se inventa ni se fuerza nada).

## Caso reproducido (issue #61)

- Base: 92,55 €
- Impuesto (IGIC 7%): 6,48 €
- Total: 99,03 €
- Línea sin tipo de impuesto asignado

Antes del fix, la línea se quedaba a 0% y el asiento no reflejaba el
IGIC. Con el fix, la línea recibe el 7% correctamente.

## Cómo probarlo

**Con los tests automáticos:**

```bash
make format
make lint
make test
```

El nuevo test de regresión es:
`Test/main/InvoiceMapperTest.php::testPrepareLinesInfersTaxRateFromTaxesArrayWhenLineOmitsIt`

**Probándolo a mano en la app** (ver `AGENTS.md`, sección "End-to-end validation"):

1. `make up` (con la clave del proveedor de IA exportada, por ejemplo
   `export GEMINI_API_KEY=...`).
2. Entra en `http://localhost:18080` (admin/admin).
3. En **Compras → AiScan**, sube una factura con IGIC/IVA donde el
   detalle no traiga el tipo por línea (por ejemplo, alguna de las
   fixtures de `Test/fixtures/` con IGIC).
4. Analiza, revisa e importa.
5. Comprueba que la línea de la factura importada ya trae el tipo de
   impuesto correcto y que el asiento contable generado incluye el
   IGIC/IVA (no solo el total de la factura).

## Qué no se infiere (a propósito)

- Facturas con varios tipos de impuesto a la vez.
- Líneas de "suplido" mezcladas con líneas normales.
- Retención de IRPF junto al desglose de impuestos.
- Un desglose con cuota 0.
- Cualquier caso en el que las cifras no cuadren dentro de un margen de
  0,01.

En estos casos se deja el comportamiento actual (sin inventar nada), en
vez de forzar una inferencia ambigua.

## Test plan

- [x] `make format` sin cambios inesperados
- [x] `make lint` sin violaciones
- [x] `make test` sin fallos (224 tests, 783 assertions, 0 fallos)
- [x] Test de regresión del issue #61 falla antes del fix y pasa después
- [x] Tests existentes de múltiples tipos de impuesto y recibos
      simplificados siguen pasando
