### PR TITLE
fix: recordar y aplicar el producto por defecto del proveedor (#69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
           echo "📋 Fixing permissions..."
           docker compose exec -T facturascripts chown -R nobody:nobody /var/www/html/Plugins/AiScan || true
 
+          echo "🔧 Deploy plugin + ensure tables (Dinamic models)..."
+          docker compose exec -T facturascripts php84 /var/www/html/Plugins/AiScan/docker/setup-aiscan.php || true
+
           echo "✅ Plugin files copied successfully"
 
       - name: Run code style check

--- a/Assets/JS/aiscan-workflow.js
+++ b/Assets/JS/aiscan-workflow.js
@@ -1863,15 +1863,83 @@
                 const refInput = document.getElementById('default_product_ref');
                 if (refInput) {
                     refInput.value = data.referencia;
+                    refInput.dataset.codproveedor = codproveedor;
                 }
                 const statusEl = document.getElementById('aiscan-default-product-status');
                 if (statusEl) {
                     statusEl.textContent = data.description || data.referencia;
                 }
+                // Issue #69: reaplicar el pin a las líneas del documento actual
+                // (incluido modo total con líneas sintéticas).
+                const doc = currentDoc();
+                if (doc?.extractedData) {
+                    doc.extractedData._product_suggestion = {
+                        referencia: data.referencia,
+                        description: data.description || '',
+                        source: 'pinned',
+                    };
+                    applyPinnedProductToLines(doc, data.referencia);
+                    refreshLineProductBadges(doc);
+                }
             }
         } catch (e) {
             // silent
         }
+    }
+
+    /**
+     * Issue #69: escribe la referencia fijada en líneas sin producto (o con
+     * sugerencia histórica previa), sin pisar un match real del usuario/IA.
+     */
+    function applyPinnedProductToLines(doc, referencia) {
+        if (!doc?.extractedData || !referencia) {
+            return;
+        }
+        if (!Array.isArray(doc.extractedData.lines)) {
+            doc.extractedData.lines = [];
+        }
+        // En modo total sin líneas, generar sintéticas y enlazar el producto.
+        const mode = doc._importMode || state.importMode;
+        if (mode === 'total' && doc.extractedData.lines.length === 0) {
+            doc.extractedData.lines = buildTotalLines(doc.extractedData);
+        }
+        doc.extractedData.lines = doc.extractedData.lines.map(line => {
+            const ref = String(line.referencia || line.sku || '').trim();
+            if (ref !== '' && line.referencia_source !== 'history' && line.referencia_source !== 'pinned') {
+                return line;
+            }
+            return {
+                ...line,
+                referencia: referencia,
+                referencia_source: 'pinned',
+            };
+        });
+    }
+
+    function refreshLineProductBadges(doc) {
+        // Si el panel de revisión está montado, re-sincronizar hidden inputs de
+        // referencia sin re-renderizar todo el formulario (evita perder foco).
+        const rows = document.querySelectorAll('#aiscan-lines-body .aiscan-line-row');
+        if (!rows.length || !Array.isArray(doc?.extractedData?.lines)) {
+            return;
+        }
+        rows.forEach((row, index) => {
+            const line = doc.extractedData.lines[index];
+            if (!line) {
+                return;
+            }
+            const refInput = row.querySelector('[data-field="referencia"]');
+            if (refInput && line.referencia) {
+                refInput.value = line.referencia;
+            }
+            const badge = row.querySelector('.aiscan-ref-badge');
+            if (badge) {
+                badge.innerHTML = buildProductMatchBadge(
+                    line.referencia || '',
+                    line.referencia_source || ''
+                );
+            }
+        });
     }
 
     function bindProductSearch() {
@@ -1926,24 +1994,51 @@
 
     async function saveDefaultProduct() {
         const refInput = document.getElementById('default_product_ref');
-        const codproveedor = refInput?.dataset.codproveedor;
+        // Fallback: si el data-attr se perdió al re-render, usar el proveedor del doc.
+        const doc = currentDoc();
+        const codproveedor = refInput?.dataset.codproveedor
+            || doc?.extractedData?.supplier?.matched_supplier_id
+            || '';
         const referencia = refInput?.value?.trim();
 
         if (!codproveedor || !referencia) {
+            const statusEl = document.getElementById('aiscan-default-product-status');
+            if (statusEl) {
+                statusEl.textContent = trans('aiscan-supplier-not-found-on-save') || 'Proveedor no resuelto';
+                statusEl.className = 'small text-danger ms-2';
+            }
             return;
+        }
+
+        if (refInput) {
+            refInput.dataset.codproveedor = codproveedor;
         }
 
         try {
             const response = await fetch('AiScanInvoice?action=set-supplier-default-product', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({codproveedor, referencia}),
+                body: JSON.stringify({
+                    codproveedor,
+                    referencia,
+                    description: document.getElementById('aiscan-product-search')?.value?.trim() || '',
+                }),
             });
             const data = await response.json();
             const statusEl = document.getElementById('aiscan-default-product-status');
             if (statusEl) {
                 statusEl.textContent = data.success ? trans('aiscan-saved') : (data.error || 'Error');
                 statusEl.className = data.success ? 'small text-success ms-2' : 'small text-danger ms-2';
+            }
+            // Issue #69: al guardar el pin, aplicarlo ya a las líneas del review.
+            if (data.success && doc?.extractedData) {
+                doc.extractedData._product_suggestion = {
+                    referencia,
+                    description: '',
+                    source: 'pinned',
+                };
+                applyPinnedProductToLines(doc, referencia);
+                refreshLineProductBadges(doc);
             }
         } catch (e) {
             // silent
@@ -2518,8 +2613,12 @@
         if (!reference) {
             return `<span class="badge text-bg-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="${escapeAttr(trans('aiscan-no-product'))}"><i class="fa-solid fa-unlink"></i></span>`;
         }
-        if (source === 'history') {
-            return `<span class="badge text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="${escapeAttr(trans('aiscan-product-suggested-history') + ': ' + reference)}"><i class="fa-solid fa-clock-rotate-left"></i></span>`;
+        if (source === 'history' || source === 'pinned') {
+            const titleKey = source === 'pinned'
+                ? 'aiscan-product-suggested-pinned'
+                : 'aiscan-product-suggested-history';
+            const icon = source === 'pinned' ? 'fa-thumbtack' : 'fa-clock-rotate-left';
+            return `<span class="badge text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="${escapeAttr(trans(titleKey) + ': ' + reference)}"><i class="fa-solid ${icon}"></i></span>`;
         }
         return `<span class="badge text-bg-success" data-bs-toggle="tooltip" data-bs-placement="top" title="${escapeAttr(reference)}"><i class="fa-solid fa-link"></i></span>`;
     }
@@ -2737,6 +2836,11 @@
         const irpfRate = subtotal > 0 && withholding > 0
             ? Math.round((withholding / subtotal) * 10000) / 100
             : 0;
+        // Issue #69: si hay producto fijado/sugerido, enlazarlo en líneas sintéticas.
+        const pinnedRef = data._product_suggestion?.referencia || '';
+        const pinFields = pinnedRef
+            ? {referencia: pinnedRef, referencia_source: data._product_suggestion?.source || 'pinned'}
+            : {};
 
         if (taxes.length > 0) {
             return taxes.map(t => ({
@@ -2746,6 +2850,7 @@
                 dtopor: 0,
                 iva: parseFloat(t.rate) || 0,
                 irpf: irpfRate,
+                ...pinFields,
             }));
         }
 
@@ -2761,6 +2866,7 @@
             dtopor: 0,
             iva: taxRate,
             irpf: irpfRate,
+            ...pinFields,
         }];
     }
 
@@ -3080,15 +3186,16 @@
             if (!Array.isArray(doc.extractedData.lines)) {
                 return;
             }
+            const source = data.source || 'history';
             doc.extractedData.lines = doc.extractedData.lines.map(line => {
                 const ref = String(line.referencia || line.sku || '').trim();
-                if (ref !== '' && line.referencia_source !== 'history') {
+                if (ref !== '' && line.referencia_source !== 'history' && line.referencia_source !== 'pinned') {
                     return line;
                 }
                 return {
                     ...line,
                     referencia: data.referencia,
-                    referencia_source: 'history',
+                    referencia_source: source === 'pinned' ? 'pinned' : 'history',
                 };
             });
         } catch (e) {
@@ -3784,11 +3891,13 @@
             applyAnalyzeResponse,
             applyManualEntryFallback,
             applyPartyTypeToSupplier,
+            applyPinnedProductToLines,
             applySelectionRange,
             buildConfidenceBadge,
             buildEmptyExtractedData,
             buildPaymentMethodSelect,
             buildProductMatchBadge,
+            buildTotalLines,
             calcAllLineTotals,
             checkTotalMismatch,
             collectFormData,

--- a/Controller/AiScanInvoice.php
+++ b/Controller/AiScanInvoice.php
@@ -472,10 +472,6 @@ class AiScanInvoice extends Controller
      */
     private function suggestSupplierProducts(array &$extracted): void
     {
-        if (empty($extracted['lines']) || !is_array($extracted['lines'])) {
-            return;
-        }
-
         $codproveedor = (string) ($extracted['supplier']['matched_supplier_id'] ?? '');
         if ($codproveedor === '') {
             return;
@@ -488,7 +484,13 @@ class AiScanInvoice extends Controller
             return;
         }
 
+        // Issue #69: exponer la sugerencia aunque no haya líneas (modo total),
+        // para que la UI y buildTotalLines puedan aplicar el producto fijado.
         $extracted['_product_suggestion'] = $suggestion;
+
+        if (empty($extracted['lines']) || !is_array($extracted['lines'])) {
+            return;
+        }
 
         $variant = new \FacturaScripts\Dinamic\Model\Variante();
         foreach ($extracted['lines'] as &$line) {

--- a/Lib/InvoiceMapper.php
+++ b/Lib/InvoiceMapper.php
@@ -143,7 +143,11 @@ class InvoiceMapper
             }
 
             $taxes = $extractedData['taxes'] ?? [];
-            $invoiceLines = $importMode === 'total' && empty($lines)
+            // Issue #69: en modo total siempre se usa la línea agregada con el
+            // producto por defecto del proveedor. Antes se caía a buildLinesMode
+            // cuando la IA/UI mandaba líneas (casi siempre), y el pin no se aplicaba
+            // de forma predecible en total mode.
+            $invoiceLines = $importMode === 'total'
                 ? $this->buildTotalModeLines($invoice, $invoiceData, $taxes, $supplier)
                 : $this->buildLinesMode($invoice, $lines, $invoiceData, $taxes, $supplier);
 
@@ -266,11 +270,15 @@ class InvoiceMapper
         array $taxes,
         ?Proveedor $supplier
     ): array {
+        // Preferir el pin del proveedor; si no hay, el histórico (#53 / #69).
         $reference = null;
         if ($supplier) {
             $defaultProduct = AiScanSupplierProduct::getForSupplier($supplier->codproveedor);
-            if ($defaultProduct) {
+            if ($defaultProduct && !empty($defaultProduct->referencia)) {
                 $reference = $defaultProduct->referencia;
+            } else {
+                $suggestion = $this->historicalContext->getSuggestedProduct($supplier->codproveedor);
+                $reference = $suggestion['referencia'] ?? null;
             }
         }
 

--- a/Lib/PurchaseLineInventoryUpdater.php
+++ b/Lib/PurchaseLineInventoryUpdater.php
@@ -170,7 +170,7 @@ class PurchaseLineInventoryUpdater
 
     /**
      * @param array<string, mixed> $sourceLine
-     * @param array<int, string> $keys
+     * @param array<int, string>   $keys
      */
     private function getNumber(array $sourceLine, array $keys, float $fallback): float
     {

--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,11 @@ test: check-docker upd
 	@echo "Running unit tests..."
 	@echo ""
 	@docker compose exec facturascripts sh -c 'cd /var/www/html && echo "→ Installing PHPUnit if needed..." && if [ ! -f vendor/bin/phpunit ]; then php84 /usr/local/bin/composer require --dev phpunit/phpunit --no-interaction; fi'
-	@docker compose exec facturascripts sh -c 'cd /var/www/html && echo "→ Setting up test environment..." && mkdir -p Test/Plugins && rm -rf Test/Plugins/* && cp -r Plugins/AiScan/Test/main/* Test/Plugins/ 2>/dev/null || true && cp Plugins/AiScan/Test/bootstrap.php Test/bootstrap.php 2>/dev/null || true && cp Plugins/AiScan/Test/install-plugins.php Test/install-plugins.php 2>/dev/null || true'
+	@docker compose exec facturascripts sh -c 'cd /var/www/html && echo "→ Setting up test environment..." && mkdir -p Test/Plugins && rm -rf Test/Plugins/* && cp -r Plugins/AiScan/Test/main/* Test/Plugins/ 2>/dev/null || true && cp Plugins/AiScan/Test/install-plugins.php Test/install-plugins.php 2>/dev/null || true && if [ -f Test/test-plugins.php ]; then echo "→ Using official Test/test-plugins.php bootstrap"; cp Plugins/AiScan/Test/bootstrap.php Test/bootstrap.php 2>/dev/null || true; else cp Plugins/AiScan/Test/bootstrap.php Test/bootstrap.php 2>/dev/null || true; fi'
 	@docker compose exec facturascripts sh -c 'cd /var/www/html && test -f Test/Plugins/install-plugins.txt || (echo "❌ Error: No tests found in Test/main/" && exit 1)'
+	@docker compose exec facturascripts sh -c 'cd /var/www/html && if [ -f Plugins/AiScan/docker/setup-aiscan.php ]; then echo "→ Ensuring AiScan plugin tables..." && php84 Plugins/AiScan/docker/setup-aiscan.php || true; fi'
 	@docker compose exec facturascripts sh -c 'cd /var/www/html && echo "→ Installing test plugins..." && php84 Test/install-plugins.php'
-	@docker compose exec facturascripts sh -c 'cd /var/www/html && test -f phpunit-plugins.xml || echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?><phpunit bootstrap=\"Test/bootstrap.php\" colors=\"true\"><testsuites><testsuite name=\"PluginTests\"><directory>Test/Plugins</directory></testsuite></testsuites></phpunit>" > phpunit-plugins.xml'
+	@docker compose exec facturascripts sh -c 'cd /var/www/html && if [ ! -f phpunit-plugins.xml ]; then if [ -f Test/test-plugins.php ]; then BOOT=Test/test-plugins.php; else BOOT=Test/bootstrap.php; fi; echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?><phpunit bootstrap=\"$$BOOT\" colors=\"true\"><testsuites><testsuite name=\"PluginTests\"><directory>Test/Plugins</directory></testsuite></testsuites></phpunit>" > phpunit-plugins.xml; fi'
 	@echo "→ Running PHPUnit tests..."
 	@echo ""
 	@docker compose exec facturascripts sh -c 'cd /var/www/html && php84 vendor/bin/phpunit -c phpunit-plugins.xml'

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -4,14 +4,32 @@
  * This file is part of AiScan plugin for FacturaScripts.
  * Copyright (C) 2026 Ernesto Serrano <info@ernesto.es>
  *
- * PHPUnit bootstrap file for testing
+ * PHPUnit bootstrap for plugin tests.
+ *
+ * Prefer the official FacturaScripts Test/test-plugins.php when present
+ * (Kernel + Plugins init). This file is a fallback used by `make test`
+ * when that bootstrap is not available.
  */
 
+use FacturaScripts\Core\Base\DataBase;
+use FacturaScripts\Core\Cache;
+use FacturaScripts\Core\Kernel;
+use FacturaScripts\Core\Plugins;
+
+// Official FS plugin bootstrap (preferred).
+$official = __DIR__ . '/test-plugins.php';
+if (is_file($official) && realpath($official) !== realpath(__FILE__)) {
+    require_once $official;
+    return;
+}
+
 // Define FacturaScripts folder
-define('FS_FOLDER', __DIR__ . '/..');
+if (!defined('FS_FOLDER')) {
+    define('FS_FOLDER', dirname(__DIR__));
+}
 
 // Load composer autoloader
-require_once FS_FOLDER . '/vendor/autoload.php';
+$loader = require FS_FOLDER . '/vendor/autoload.php';
 
 // Load FacturaScripts configuration
 if (file_exists(FS_FOLDER . '/config.php')) {
@@ -28,8 +46,6 @@ if (!defined('FS_TIMEZONE')) {
 }
 
 // Constants normally defined by Kernel::init() from DB settings.
-// Provide defaults so tests work even when phpunit-plugins.xml uses this
-// bootstrap instead of the FacturaScripts Test/test-plugins.php bootstrap.
 if (!defined('FS_NF0')) {
     define('FS_NF0', 2);
 }
@@ -54,14 +70,31 @@ if (!defined('FS_ITEM_LIMIT')) {
     define('FS_ITEM_LIMIT', 50);
 }
 
-// Register plugin namespaces with the autoloader
-$loader = require FS_FOLDER . '/vendor/autoload.php';
+// Ensure PSR-4 roots are registered (Dinamic is required for Proveedor, etc.)
+$loader->addPsr4('FacturaScripts\\Core\\', FS_FOLDER . '/Core/');
+$loader->addPsr4('FacturaScripts\\Dinamic\\', FS_FOLDER . '/Dinamic/');
+$loader->addPsr4('FacturaScripts\\Plugins\\', FS_FOLDER . '/Plugins/');
+$loader->addPsr4('FacturaScripts\\Plugins\\AiScan\\', FS_FOLDER . '/Plugins/AiScan/');
+$loader->addPsr4('FacturaScripts\\Test\\', FS_FOLDER . '/Test/');
 
-// Register FacturaScripts Core
-$loader->addPsr4('FacturaScripts\\Core\\', FS_FOLDER . '/Core');
-
-// Register AiScan
-$loader->addPsr4('FacturaScripts\\Plugins\\AiScan\\', FS_FOLDER . '/Plugins/AiScan');
-
-// If your plugin depends on other plugins, register them here as well
-// Example: $loader->addPsr4('FacturaScripts\\Plugins\\OtherPlugin\\', FS_FOLDER . '/Plugins/OtherPlugin');
+// Boot Kernel + plugins when possible (same spirit as Test/test-plugins.php).
+try {
+    if (class_exists(DataBase::class)) {
+        $db = new DataBase();
+        if (method_exists($db, 'connect')) {
+            $db->connect();
+        }
+    }
+    if (class_exists(Cache::class) && method_exists(Cache::class, 'clear')) {
+        Cache::clear();
+    }
+    if (class_exists(Kernel::class) && method_exists(Kernel::class, 'init')) {
+        Kernel::init();
+    }
+    if (class_exists(Plugins::class) && method_exists(Plugins::class, 'init')) {
+        Plugins::init();
+    }
+} catch (Throwable $e) {
+    // Keep going: pure unit tests must still run without a full FS boot.
+    fwrite(STDERR, '[AiScan test bootstrap] partial init: ' . $e->getMessage() . PHP_EOL);
+}

--- a/Test/js/aiscan-workflow.test.js
+++ b/Test/js/aiscan-workflow.test.js
@@ -757,3 +757,47 @@ test('manual entry payload remains importable after user fills fields', () => {
     // Import gate treats needs_review/ready as non-failed
     assert.notEqual(doc.status, 'failed');
 });
+
+test('applyPinnedProductToLines rellena líneas vacías y respeta matches reales (#69)', () => {
+    const {hooks} = loadTestHooks();
+    const doc = {
+        extractedData: {
+            lines: [
+                {descripcion: 'Sin producto', cantidad: 1, pvpunitario: 10},
+                {descripcion: 'Ya enlazado', cantidad: 1, pvpunitario: 20, referencia: 'REAL-1'},
+                {descripcion: 'Histórico', cantidad: 1, pvpunitario: 5, referencia: 'OLD', referencia_source: 'history'},
+            ],
+        },
+        _importMode: 'lines',
+    };
+
+    hooks.applyPinnedProductToLines(doc, 'PIN-99');
+
+    assert.equal(doc.extractedData.lines[0].referencia, 'PIN-99');
+    assert.equal(doc.extractedData.lines[0].referencia_source, 'pinned');
+    assert.equal(doc.extractedData.lines[1].referencia, 'REAL-1');
+    assert.equal(doc.extractedData.lines[2].referencia, 'PIN-99');
+    assert.equal(doc.extractedData.lines[2].referencia_source, 'pinned');
+});
+
+test('buildTotalLines incluye producto fijado de _product_suggestion (#69)', () => {
+    const {hooks} = loadTestHooks();
+    const lines = hooks.buildTotalLines({
+        invoice: {summary: 'Servicio', subtotal: 100, tax_amount: 21, total: 121},
+        taxes: [{base: 100, rate: 21, amount: 21}],
+        _product_suggestion: {referencia: 'SERV-1', source: 'pinned'},
+    });
+
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0].referencia, 'SERV-1');
+    assert.equal(lines[0].referencia_source, 'pinned');
+    assert.equal(lines[0].pvpunitario, 100);
+});
+
+test('buildProductMatchBadge distingue pinned e history (#69)', () => {
+    const {hooks} = loadTestHooks();
+    const pinned = hooks.buildProductMatchBadge('PIN-1', 'pinned');
+    const history = hooks.buildProductMatchBadge('HIST-1', 'history');
+    assert.match(pinned, /fa-thumbtack/);
+    assert.match(history, /fa-clock-rotate-left/);
+});

--- a/Test/main/AiScanSupplierProductTest.php
+++ b/Test/main/AiScanSupplierProductTest.php
@@ -38,6 +38,16 @@ final class AiScanSupplierProductTest extends TestCase
     /** @var string[] */
     private array $codproveedoresToClear = [];
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!class_exists(Proveedor::class)) {
+            $this->markTestSkipped('FacturaScripts Dinamic\Model\Proveedor no disponible en este entorno.');
+        }
+        // Asegurar que la tabla del modelo existe (CI Docker copia el plugin sin deploy).
+        new AiScanSupplierProduct();
+    }
+
     protected function tearDown(): void
     {
         foreach ($this->codproveedoresToClear as $cod) {

--- a/Test/main/AiScanSupplierProductTest.php
+++ b/Test/main/AiScanSupplierProductTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * This file is part of AiScan plugin for FacturaScripts.
+ * Copyright (C) 2026 Ernesto Serrano <info@ernesto.es>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Plugins;
+
+use FacturaScripts\Dinamic\Model\Proveedor;
+use FacturaScripts\Dinamic\Model\Variante;
+use FacturaScripts\Plugins\AiScan\Lib\HistoricalContextService;
+use FacturaScripts\Plugins\AiScan\Model\AiScanSupplierProduct;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #69: el producto por defecto del proveedor debe persistir y recordarse
+ * en facturas posteriores del mismo codproveedor.
+ */
+final class AiScanSupplierProductTest extends TestCase
+{
+    /** @var Proveedor[] */
+    private array $suppliersToDelete = [];
+
+    /** @var string[] */
+    private array $codproveedoresToClear = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->codproveedoresToClear as $cod) {
+            $existing = AiScanSupplierProduct::getForSupplier($cod);
+            if ($existing) {
+                $existing->delete();
+            }
+        }
+
+        foreach ($this->suppliersToDelete as $supplier) {
+            if ($supplier->exists()) {
+                $address = $supplier->getDefaultAddress();
+                if ($address->exists()) {
+                    $address->delete();
+                }
+                $supplier->delete();
+            }
+        }
+    }
+
+    /**
+     * @testdox setForSupplier + getForSupplier persisten y recuperan el producto fijado (#69)
+     */
+    public function testPinPersistsAcrossLookups(): void
+    {
+        $supplier = $this->createSupplier();
+        $ref = $this->anyProductReference();
+        if ($ref === null) {
+            $this->markTestSkipped('No hay productos en la BD de prueba.');
+        }
+
+        $this->codproveedoresToClear[] = $supplier->codproveedor;
+
+        $this->assertTrue(
+            AiScanSupplierProduct::setForSupplier($supplier->codproveedor, $ref, 'Producto habitual'),
+            'setForSupplier debe guardar sin error'
+        );
+
+        $found = AiScanSupplierProduct::getForSupplier($supplier->codproveedor);
+        $this->assertNotNull($found, 'getForSupplier debe devolver la fila guardada');
+        $this->assertSame($ref, $found->referencia);
+        $this->assertSame('Producto habitual', $found->description);
+
+        // Segunda lectura (simula la siguiente factura del mismo proveedor)
+        $again = AiScanSupplierProduct::getForSupplier($supplier->codproveedor);
+        $this->assertNotNull($again);
+        $this->assertSame($ref, $again->referencia);
+    }
+
+    /**
+     * @testdox setForSupplier actualiza la referencia si ya existía un pin (#69)
+     */
+    public function testPinCanBeUpdated(): void
+    {
+        $supplier = $this->createSupplier();
+        $ref = $this->anyProductReference();
+        if ($ref === null) {
+            $this->markTestSkipped('No hay productos en la BD de prueba.');
+        }
+
+        $this->codproveedoresToClear[] = $supplier->codproveedor;
+
+        $this->assertTrue(AiScanSupplierProduct::setForSupplier($supplier->codproveedor, $ref, 'v1'));
+        $this->assertTrue(AiScanSupplierProduct::setForSupplier($supplier->codproveedor, $ref, 'v2'));
+
+        $found = AiScanSupplierProduct::getForSupplier($supplier->codproveedor);
+        $this->assertNotNull($found);
+        $this->assertSame('v2', $found->description);
+        $this->assertSame(1, count(AiScanSupplierProduct::all(
+            [new \FacturaScripts\Core\Base\DataBase\DataBaseWhere('codproveedor', $supplier->codproveedor)],
+            [],
+            0,
+            10
+        )));
+    }
+
+    /**
+     * @testdox getSuggestedProduct prioriza el producto fijado (pinned) sobre el histórico (#69)
+     */
+    public function testSuggestedProductPrefersPinned(): void
+    {
+        $supplier = $this->createSupplier();
+        $ref = $this->anyProductReference();
+        if ($ref === null) {
+            $this->markTestSkipped('No hay productos en la BD de prueba.');
+        }
+
+        $this->codproveedoresToClear[] = $supplier->codproveedor;
+        $this->assertTrue(AiScanSupplierProduct::setForSupplier($supplier->codproveedor, $ref, 'Fijado'));
+
+        $service = new HistoricalContextService();
+        $suggestion = $service->getSuggestedProduct($supplier->codproveedor);
+
+        $this->assertNotNull($suggestion);
+        $this->assertSame($ref, $suggestion['referencia']);
+        $this->assertSame('pinned', $suggestion['source']);
+    }
+
+    /**
+     * @testdox getForSupplier con codproveedor desconocido devuelve null (#69)
+     */
+    public function testUnknownSupplierReturnsNull(): void
+    {
+        $this->assertNull(AiScanSupplierProduct::getForSupplier('NOEXISTE99'));
+    }
+
+    private function createSupplier(): Proveedor
+    {
+        $supplier = new Proveedor();
+        $supplier->nombre = 'AiScan DefaultProd ' . mt_rand(10000, 99999);
+        $supplier->razonsocial = $supplier->nombre;
+        $supplier->cifnif = 'B' . mt_rand(10000000, 99999999);
+        $supplier->personafisica = false;
+        $this->assertTrue($supplier->save());
+        $this->suppliersToDelete[] = $supplier;
+
+        return $supplier;
+    }
+
+    private function anyProductReference(): ?string
+    {
+        $variant = new Variante();
+        foreach ($variant->all([], [], 0, 1) as $row) {
+            $ref = trim((string) $row->referencia);
+            if ($ref !== '') {
+                return $ref;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Translation/en_EN.json
+++ b/Translation/en_EN.json
@@ -121,6 +121,7 @@
     "aiscan-plugin-disabled": "AiScan plugin is disabled.",
     "aiscan-proceed-to-import": "Proceed to import",
     "aiscan-product-suggested-history": "Suggested from supplier history",
+    "aiscan-product-suggested-pinned": "Supplier default product",
     "aiscan-provider": "Provider",
     "aiscan-provider-browser-prompt": "Browser Prompt API (experimental)",
     "aiscan-provider-gemini": "Google Gemini",

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -121,6 +121,7 @@
     "aiscan-plugin-disabled": "El plugin AiScan está desactivado.",
     "aiscan-proceed-to-import": "Proceder a importar",
     "aiscan-product-suggested-history": "Sugerido del histórico del proveedor",
+    "aiscan-product-suggested-pinned": "Producto predeterminado del proveedor",
     "aiscan-provider": "Proveedor IA",
     "aiscan-provider-browser-prompt": "Browser Prompt API (experimental)",
     "aiscan-provider-gemini": "Google Gemini",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- Producto por defecto del proveedor (#69): se recuerda y aplica en facturas siguientes
+  (incluido modo total), se rellena al cargar/guardar el pin en la UI y se expone
+  `_product_suggestion` aunque no haya líneas extraídas
 - Producto habitual del proveedor (#53): limpia referencias inventadas por la IA, sugiere al
   elegir proveedor en la revisión, y si el histórico no tiene referencias enlazadas intenta
   emparejar por **descripción** de líneas anteriores


### PR DESCRIPTION
## Resumen

Corrige que el **producto por defecto del proveedor** no se recordaba ni se aplicaba en facturas siguientes del mismo proveedor (especialmente en **modo total**).

Closes #69

## Problema

1. En modo total, si la IA/UI enviaba líneas, el mapper usaba `buildLinesMode` y el pin no se aplicaba de forma fiable.
2. Tras guardar el pin en la primera factura, las líneas del review no se rellenaban solas.
3. En facturas sin líneas extraídas no se exponía `_product_suggestion`, así que las líneas sintéticas de modo total nacían sin producto.
4. Al cargar el pin en la UI solo se rellenaba el input, no las líneas.

## Solución

- `importMode === 'total'` siempre usa `buildTotalModeLines` (con pin / histórico).
- `suggestSupplierProducts` guarda `_product_suggestion` aunque no haya líneas.
- Al **cargar** y **guardar** el pin en la UI se aplica a las líneas del documento.
- `buildTotalLines` enlaza la referencia fijada.
- Badge distintivo para producto *pinned*.

## Tests

- `AiScanSupplierProductTest` (persistencia + prioridad pinned en `getSuggestedProduct`)
- JS: `applyPinnedProductToLines`, `buildTotalLines` con pin, badge pinned

## Cómo probar

1. Importar factura del proveedor X, guardar un producto por defecto.
2. Comprobar que las líneas del review se rellenan al guardar.
3. Importar otra factura del mismo proveedor en **modo total**.
4. El campo de producto por defecto debe venir relleno y la línea importada enlazada.

## Revisora

@AnaLaRama