### PR TITLE
Configure playground and Docker for IGIC invoicing

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -24,12 +24,14 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            const zlib = require('zlib');
             const marker = '<!-- facturascripts-playground-preview -->';
             const playgroundUrl = 'https://erseco.github.io/facturascripts-playground/';
             const imageUrl = 'https://raw.githubusercontent.com/erseco/facturascripts-playground/main/ogimage.png';
             const { owner, repo } = context.repo;
             const pullRequest = context.payload.pull_request;
-            const branchZipUrl = `https://github.com/${owner}/${repo}/archive/refs/heads/${pullRequest.head.ref}.zip`;
+            const branchRef = pullRequest.head.ref;
+            const branchZipUrl = `https://github.com/${owner}/${repo}/archive/refs/heads/${branchRef}.zip`;
             const fs = require('fs');
             const mainBranchZipUrl = `https://github.com/${owner}/${repo}/archive/refs/heads/main.zip`;
             const blueprint = JSON.parse(fs.readFileSync('blueprint.json', 'utf8'));
@@ -44,15 +46,42 @@ jobs:
             blueprint.plugins = [...blueprint.plugins];
             blueprint.plugins[pluginIndex] = branchZipUrl;
 
-            function toBase64Url(value) {
-              return Buffer.from(value, 'utf8')
+            // Compact JSON + gzip + base64url (same wire format as the Playground
+            // shell / action-facturascripts-playground-pr-preview). Plain base64 of
+            // the full AiScan seed is ~12 KB and hits HTTP 414 on static hosts.
+            function toBase64Url(buf) {
+              return Buffer.from(buf)
                 .toString('base64')
                 .replace(/\+/g, '-')
                 .replace(/\//g, '_')
                 .replace(/=+$/g, '');
             }
 
-            const previewUrl = `${playgroundUrl}?blueprint-data=${toBase64Url(JSON.stringify(blueprint))}`;
+            function encodeBlueprintParam(payload) {
+              const utf8 = Buffer.from(JSON.stringify(payload), 'utf8');
+              try {
+                const gzipped = zlib.gzipSync(utf8, { level: 9 });
+                if (gzipped.length < utf8.length) {
+                  return toBase64Url(gzipped);
+                }
+              } catch (_) {
+                // fall through
+              }
+              return toBase64Url(utf8);
+            }
+
+            const encoded = encodeBlueprintParam(blueprint);
+            const previewUrl = `${playgroundUrl}?blueprint=${encoded}`;
+            const maxSafe = 8000;
+            if (previewUrl.length > maxSafe) {
+              core.warning(
+                `Preview URL is ${previewUrl.length} chars (> ${maxSafe}); ` +
+                  'may still hit HTTP 414. Prefer trimming blueprint.json seed data.'
+              );
+            } else {
+              core.info(`Preview URL length: ${previewUrl.length} chars (gzipped)`);
+            }
+
             const body = [
               marker,
               '## FacturaScripts Playground Preview',
@@ -62,7 +91,7 @@ jobs:
               '</a><br>',
               `<small><a href="${previewUrl}">Try this PR in your browser</a></small>`,
               '',
-              `This preview is generated automatically for the \`${pullRequest.head.ref}\` branch and loads the plugin directly from the PR branch ZIP in FacturaScripts Playground.`
+              `This preview is generated automatically for the \`${branchRef}\` branch and loads the plugin directly from the PR branch ZIP in FacturaScripts Playground.`
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,16 +6,21 @@
 make upd
 ```
 
+The stack seeds a **Canary Islands** demo company (IGIC 7% by default, Spanish PGC
+accounting plan, sample suppliers/products) from `blueprint.json` so purchase invoices
+can be imported and posted with accounting entries without manual Wizard steps.
+
 ## 2. Open the app
 
-Go to `http://localhost:8080` and log in with:
+Go to `http://localhost:8080` (or `http://localhost:18080` if you use the committed
+`docker-compose.override.yml`) and log in with:
 
 - **Username:** `admin`
 - **Password:** `admin`
 
 ## 3. Enable AiScan
 
-Enable the plugin from **Admin Panel → Plugins**.
+Enable the plugin from **Admin Panel → Plugins** (already enabled in the Docker auto-setup).
 
 ## 4. Configure an AI provider
 
@@ -25,6 +30,9 @@ Open **AiScan Configuration** and set at least one provider credential:
 - Google Gemini
 - Mistral
 - OpenAI-compatible endpoint
+
+Or export keys before `make up` (`GEMINI_API_KEY`, `OPENAI_API_KEY`, …) so
+`docker/setup-aiscan.php` stores them on boot.
 
 ### Optional: debug / mock mode (no API keys)
 
@@ -37,14 +45,18 @@ Useful to verify the review UI and supplier default product suggestions without 
 
 ## 5. Scan a supplier invoice
 
-1. Open a purchase invoice.
-2. Click **Scan Invoice**.
-3. Upload a PDF or image invoice.
-4. Review the extracted data.
-5. In the import summary, optionally enable **Update stock and purchase data from invoice lines**.
-6. Save the purchase invoice and attached source file.
+1. Open **Compras → AiScan** (or a purchase invoice and **Scan Invoice**).
+2. Upload a PDF or image from `Test/fixtures/` (many are IGIC Canary invoices).
+3. Review the extracted data (tax codes such as `IGIC7` / `IGIC0` should match the seeded taxes).
+4. In the import summary, optionally enable **Update stock and purchase data from invoice lines**.
+5. Save the purchase invoice and attached source file; the accounting entry should include IGIC.
 
-## 6. Stop the environment
+## 6. Browser playground
+
+[Try AiScan in FacturaScripts Playground](https://erseco.github.io/facturascripts-playground/?blueprint=https%3A%2F%2Fraw.githubusercontent.com%2Ferseco%2Ffacturascripts-plugin-AiScan%2Frefs%2Fheads%2Fmain%2Fblueprint.json)
+using the same `blueprint.json` (`install` + `settings` + seed).
+
+## 7. Stop the environment
 
 ```bash
 make down

--- a/blueprint.json
+++ b/blueprint.json
@@ -3,7 +3,7 @@
   "meta": {
     "title": "AiScan Playground Demo",
     "author": "erseco",
-    "description": "Ejecuta AiScan en FacturaScripts Playground con el plugin cargado desde este repositorio."
+    "description": "Ejecuta AiScan en FacturaScripts Playground listo para facturar en Canarias (IGIC, plan contable PGC, proveedores y productos demo)."
   },
   "debug": {
     "enabled": true
@@ -12,7 +12,7 @@
   "siteOptions": {
     "title": "AiScan Playground Demo",
     "locale": "es_ES",
-    "timezone": "Europe/Madrid"
+    "timezone": "Atlantic/Canary"
   },
   "login": {
     "username": "admin",
@@ -26,10 +26,49 @@
     "empresa": "Pepita Gómez - Autónoma",
     "cifnif": "125478938W",
     "tipoidfiscal": "NIF",
+    "direccion": "Calle Castillo 15",
+    "codpostal": "38003",
+    "ciudad": "Santa Cruz de Tenerife",
+    "provincia": "Santa Cruz de Tenerife",
     "regimeniva": "General",
-    "defaultplan": true
+    "codimpuesto": "IGIC7",
+    "defaultplan": true,
+    "costpricepolicy": "",
+    "ventasinstock": false,
+    "updatesupplierprices": true
+  },
+  "settings": {
+    "default": {
+      "codpais": "ESP",
+      "coddivisa": "EUR",
+      "codimpuesto": "IGIC7",
+      "codpago": "CONT",
+      "codserie": "A",
+      "tipoidfiscal": "NIF",
+      "regimeniva": "General",
+      "updatesupplierprices": true,
+      "ventasinstock": false
+    }
   },
   "seed": {
+    "customers": [
+      {
+        "codcliente": "C-DEMO-01",
+        "nombre": "Cliente Demo Canarias",
+        "razonsocial": "Cliente Demo Canarias S.L.",
+        "cifnif": "B38099887",
+        "tipoidfiscal": "CIF",
+        "regimeniva": "General",
+        "email": "cliente@example.com",
+        "telefono1": "+34922222111",
+        "direccion": "Av. de Anaga 1",
+        "codpostal": "38001",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
+        "_unique": "codcliente"
+      }
+    ],
     "suppliers": [
       {
         "nombre": "Clínica Dental Sonrisa",
@@ -37,6 +76,11 @@
         "cifnif": "B38456789",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Calle Méndez Núñez 8",
+        "codpostal": "38002",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -45,6 +89,11 @@
         "cifnif": "B38901234",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Calle Imeldo Serís 22",
+        "codpostal": "38003",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -53,6 +102,11 @@
         "cifnif": "B38012345",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Av. Tres de Mayo 40",
+        "codpostal": "38005",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -61,6 +115,11 @@
         "cifnif": "B38033344",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Camino Real 12",
+        "codpostal": "38509",
+        "ciudad": "Güímar",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -69,6 +128,11 @@
         "cifnif": "B38778899",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Calle Bethencourt Alfonso 5",
+        "codpostal": "38002",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -77,6 +141,11 @@
         "cifnif": "B38111222",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Calle Robayna 3",
+        "codpostal": "38004",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -85,6 +154,11 @@
         "cifnif": "E76234567",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Mirador de la Concepción s/n",
+        "codpostal": "38205",
+        "ciudad": "La Laguna",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -93,6 +167,11 @@
         "cifnif": "A38345678",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Polígono Costa Sur, nave 4",
+        "codpostal": "38110",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -101,6 +180,11 @@
         "cifnif": "B38556677",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Calle El Pilar 18",
+        "codpostal": "38002",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -109,6 +193,11 @@
         "cifnif": "A38789012",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Plaza Weyler 2",
+        "codpostal": "38003",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -117,6 +206,11 @@
         "cifnif": "B38112233",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Calle San Francisco 9",
+        "codpostal": "38001",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -125,6 +219,11 @@
         "cifnif": "P3800000B",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Plaza de España s/n",
+        "codpostal": "38003",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -133,6 +232,11 @@
         "cifnif": "B38334455",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Calle del Castillo 30",
+        "codpostal": "38003",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -141,6 +245,11 @@
         "cifnif": "S3511001I",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Av. José Manuel Guimerá 10",
+        "codpostal": "38071",
+        "ciudad": "Santa Cruz de Tenerife",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -149,6 +258,11 @@
         "cifnif": "B38889900",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Playa de Las Américas s/n",
+        "codpostal": "38660",
+        "ciudad": "Arona",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -157,6 +271,11 @@
         "cifnif": "B76567890",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Calle Cruz Verde 7",
+        "codpostal": "35001",
+        "ciudad": "Las Palmas de Gran Canaria",
+        "provincia": "Las Palmas",
+        "codpais": "ESP",
         "_unique": "cifnif"
       },
       {
@@ -165,6 +284,11 @@
         "cifnif": "A38333444",
         "tipoidfiscal": "CIF",
         "regimeniva": "General",
+        "direccion": "Parque Científico Tecnológico",
+        "codpostal": "38204",
+        "ciudad": "La Laguna",
+        "provincia": "Santa Cruz de Tenerife",
+        "codpais": "ESP",
         "_unique": "cifnif"
       }
     ],
@@ -172,79 +296,152 @@
       {
         "referencia": "SERV-DEV",
         "descripcion": "Desarrollo de software",
-        "precio": 75.00,
+        "precio": 75.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-DISENO",
         "descripcion": "Diseño gráfico y web",
-        "precio": 60.00,
+        "precio": 60.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-RRSS",
         "descripcion": "Gestión de redes sociales",
-        "precio": 350.00,
+        "precio": 350.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-PUBLI",
         "descripcion": "Publicidad digital",
-        "precio": 500.00,
+        "precio": 500.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-CONSUL",
         "descripcion": "Consultoría y formación",
-        "precio": 80.00,
+        "precio": 80.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-HOSTING",
         "descripcion": "Hosting, dominios y SSL",
         "precio": 9.99,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-TESTING",
         "descripcion": "Testing y auditoría",
-        "precio": 65.00,
+        "precio": 65.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-MANTEN",
         "descripcion": "Mantenimiento web",
-        "precio": 200.00,
+        "precio": 200.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-FOTO",
         "descripcion": "Fotografía y vídeo profesional",
-        "precio": 120.00,
+        "precio": 120.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-RENDER",
         "descripcion": "Renders 3D y tours virtuales",
-        "precio": 450.00,
+        "precio": 450.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-PLANOS",
         "descripcion": "Planos y documentación técnica",
-        "precio": 180.00,
+        "precio": 180.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "SERV-MIGRA",
         "descripcion": "Migración de datos y servidores",
-        "precio": 90.00,
+        "precio": 90.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       },
       {
         "referencia": "GASTOS-GEN",
         "descripcion": "Gastos generales",
-        "precio": 0.00,
+        "precio": 0.0,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": false,
+        "nostock": true,
+        "_unique": "referencia"
+      },
+      {
+        "referencia": "MAT-OFICINA",
+        "descripcion": "Material de oficina",
+        "precio": 12.5,
+        "codimpuesto": "IGIC7",
+        "secompra": true,
+        "sevende": true,
+        "nostock": false,
+        "stockfis": 25,
+        "_unique": "referencia"
+      },
+      {
+        "referencia": "EXENTO-0",
+        "descripcion": "Concepto exento / IGIC 0%",
+        "precio": 100.0,
+        "codimpuesto": "IGIC0",
+        "secompra": true,
+        "sevende": true,
+        "nostock": true,
         "_unique": "referencia"
       }
     ]

--- a/blueprint.json
+++ b/blueprint.json
@@ -44,6 +44,7 @@
       "codimpuesto": "IGIC7",
       "codpago": "CONT",
       "codserie": "A",
+      "codserierec": "R",
       "tipoidfiscal": "NIF",
       "regimeniva": "General",
       "updatesupplierprices": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,11 +32,18 @@ services:
       FS_INITIAL_PASS: admin
       FS_LANG: es_ES
       FS_TIMEZONE: Europe/Madrid
-      # Company setup (auto-completes Wizard)
+      # Company setup (auto-completes Wizard) — Canarias / IGIC demo (matches blueprint.json)
       FS_CODPAIS: ESP
-      FS_COMPANY_NAME: "Empresa Demo AiScan"
-      FS_COMPANY_CIF: "B12345678"
+      FS_COMPANY_NAME: "Pepita Gómez - Autónoma"
+      FS_COMPANY_CIF: "125478938W"
       FS_COMPANY_REGIMENIVA: General
+      FS_COMPANY_TIPOIDFISCAL: NIF
+      FS_COMPANY_ADDRESS: "Calle Castillo 15"
+      FS_COMPANY_POSTAL: "38003"
+      FS_COMPANY_CITY: "Santa Cruz de Tenerife"
+      FS_COMPANY_PROVINCE: "Santa Cruz de Tenerife"
+      FS_DEFAULT_TAX: IGIC7
+      FS_LOAD_ACCOUNTING_PLAN: "true"
       # Seed data: load suppliers and products from blueprint.json
       FS_SEED_FILE: /var/www/html/Plugins/AiScan/blueprint.json
       # Debug mode (set to false in production)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       FS_COMPANY_CITY: "Santa Cruz de Tenerife"
       FS_COMPANY_PROVINCE: "Santa Cruz de Tenerife"
       FS_DEFAULT_TAX: IGIC7
+      FS_DEFAULT_SERIE: A
       FS_LOAD_ACCOUNTING_PLAN: "true"
       # Seed data: load suppliers and products from blueprint.json
       FS_SEED_FILE: /var/www/html/Plugins/AiScan/blueprint.json

--- a/docker/setup-aiscan.php
+++ b/docker/setup-aiscan.php
@@ -3,7 +3,10 @@
 /**
  * AiScan Docker auto-setup script.
  *
- * Configures AiScan plugin settings (API keys) from environment variables.
+ * Configures AiScan plugin settings (API keys) from environment variables
+ * and aligns the company/tax defaults with the playground blueprint so the
+ * local stack can post purchase invoices with IGIC and accounting entries.
+ *
  * Wizard completion and seed data loading are handled by the base container
  * (setup-facturascripts.php and seed-facturascripts.php via FS_SEED_FILE).
  *
@@ -26,6 +29,7 @@ require_once $configFile;
 
 use FacturaScripts\Core\Kernel;
 use FacturaScripts\Core\Plugins;
+use FacturaScripts\Core\Tools;
 
 Kernel::init();
 Plugins::deploy(true, true);
@@ -58,10 +62,133 @@ foreach ($aiscanModels as $name) {
 }
 echo "[AiScan] Plugin tables ensured.\n";
 
+// Align company + defaults for Canary Islands billing (IGIC / PGC).
+configureBillingDefaults();
+
 // Configure API keys from environment variables
 configureApiKeys();
 
 echo "[AiScan] Setup completed.\n";
+
+/**
+ * Ensure the instance can create and post invoices with IGIC and asientos.
+ *
+ * Reads optional overrides from the same install-oriented env vars used by
+ * alpine-facturascripts, falling back to the Canarias demo used in blueprint.json.
+ */
+function configureBillingDefaults(): void
+{
+    $codpais = getenv('FS_CODPAIS') ?: 'ESP';
+    $companyName = getenv('FS_COMPANY_NAME') ?: 'Pepita Gómez - Autónoma';
+    $companyCif = getenv('FS_COMPANY_CIF') ?: '125478938W';
+    $regimenIva = getenv('FS_COMPANY_REGIMENIVA') ?: 'General';
+    $defaultTax = getenv('FS_DEFAULT_TAX') ?: 'IGIC7';
+    $companyAddress = getenv('FS_COMPANY_ADDRESS') ?: 'Calle Castillo 15';
+    $companyPostal = getenv('FS_COMPANY_POSTAL') ?: '38003';
+    $companyCity = getenv('FS_COMPANY_CITY') ?: 'Santa Cruz de Tenerife';
+    $companyProvince = getenv('FS_COMPANY_PROVINCE') ?: 'Santa Cruz de Tenerife';
+
+    // Ensure country tax CSV rows (IVA + IGIC + IPSI) exist.
+    $taxModel = new \FacturaScripts\Dinamic\Model\Impuesto();
+    if ($taxModel->count() === 0) {
+        echo "[AiScan] WARNING: no taxes found after setup.\n";
+    }
+
+    if (!$taxModel->loadFromCode($defaultTax)) {
+        echo "[AiScan] WARNING: default tax {$defaultTax} not found; keeping current default.\n";
+        $defaultTax = (string) Tools::settings('default', 'codimpuesto', 'IVA21');
+    }
+
+    $empresa = new \FacturaScripts\Dinamic\Model\Empresa();
+    $empresaReady = $empresa->loadFromCode(1);
+    if ($empresaReady) {
+        $empresa->nombre = $companyName;
+        $empresa->nombrecorto = Tools::textBreak($companyName, 32);
+        $empresa->cifnif = $companyCif;
+        $empresa->tipoidfiscal = getenv('FS_COMPANY_TIPOIDFISCAL') ?: 'NIF';
+        $empresa->codpais = $codpais;
+        $empresa->regimeniva = $regimenIva;
+        $empresa->direccion = $companyAddress;
+        $empresa->codpostal = $companyPostal;
+        $empresa->ciudad = $companyCity;
+        $empresa->provincia = $companyProvince;
+        if ($empresa->save()) {
+            echo "[AiScan] Company configured: {$empresa->nombre} ({$empresa->cifnif}).\n";
+        } else {
+            echo "[AiScan] WARNING: could not save company defaults.\n";
+        }
+    }
+
+    $codalmacen = (string) Tools::settings('default', 'codalmacen', '');
+    if ($codalmacen === '') {
+        $almacen = new \FacturaScripts\Dinamic\Model\Almacen();
+        foreach ($almacen->all([], [], 0, 1) as $first) {
+            $codalmacen = (string) $first->codalmacen;
+            $first->codpais = $codpais;
+            $first->direccion = $companyAddress;
+            $first->codpostal = $companyPostal;
+            $first->ciudad = $companyCity;
+            $first->provincia = $companyProvince;
+            $first->save();
+            break;
+        }
+    }
+
+    Tools::settingsSet('default', 'codpais', $codpais);
+    Tools::settingsSet('default', 'coddivisa', 'EUR');
+    Tools::settingsSet('default', 'codimpuesto', $defaultTax);
+    Tools::settingsSet('default', 'codpago', Tools::settings('default', 'codpago', 'CONT') ?: 'CONT');
+    Tools::settingsSet('default', 'codserie', Tools::settings('default', 'codserie', 'A') ?: 'A');
+    Tools::settingsSet('default', 'tipoidfiscal', 'NIF');
+    Tools::settingsSet('default', 'regimeniva', $regimenIva);
+    Tools::settingsSet('default', 'updatesupplierprices', true);
+    Tools::settingsSet('default', 'ventasinstock', false);
+    if ($codalmacen !== '') {
+        Tools::settingsSet('default', 'codalmacen', $codalmacen);
+    }
+    if ($empresaReady) {
+        Tools::settingsSet('default', 'idempresa', $empresa->idempresa);
+    }
+    Tools::settingsSave();
+    echo "[AiScan] Default tax: {$defaultTax}; warehouse: " . ($codalmacen ?: '(none)') . ".\n";
+
+    ensureAccountingPlan($codpais);
+}
+
+/**
+ * Import the country default accounting plan when no accounts exist yet.
+ * Required so posted invoices can generate asientos with IGIC subcuentas.
+ */
+function ensureAccountingPlan(string $codpais): void
+{
+    $cuenta = new \FacturaScripts\Dinamic\Model\Cuenta();
+    if ($cuenta->count() > 0) {
+        echo "[AiScan] Accounting plan already present ({$cuenta->count()} accounts).\n";
+        return;
+    }
+
+    $planFile = FS_FOLDER . '/Dinamic/Data/Codpais/' . $codpais . '/defaultPlan.csv';
+    if (!is_file($planFile)) {
+        echo "[AiScan] WARNING: accounting plan file missing: {$planFile}\n";
+        return;
+    }
+
+    $ejercicio = new \FacturaScripts\Dinamic\Model\Ejercicio();
+    $ejercicios = $ejercicio->all([], [], 0, 1);
+    if (empty($ejercicios)) {
+        echo "[AiScan] WARNING: no exercise found; cannot import accounting plan.\n";
+        return;
+    }
+
+    $importClass = '\\FacturaScripts\\Dinamic\\Lib\\Accounting\\AccountingPlanImport';
+    if (!class_exists($importClass)) {
+        echo "[AiScan] WARNING: AccountingPlanImport not available.\n";
+        return;
+    }
+
+    (new $importClass())->importCSV($planFile, $ejercicios[0]->codejercicio);
+    echo "[AiScan] Accounting plan imported for exercise {$ejercicios[0]->codejercicio}.\n";
+}
 
 function configureApiKeys(): void
 {

--- a/docker/setup-aiscan.php
+++ b/docker/setup-aiscan.php
@@ -134,11 +134,18 @@ function configureBillingDefaults(): void
         }
     }
 
+    $codserie = ensureDefaultSerie();
+    $codejercicio = '';
+    if ($empresaReady) {
+        $codejercicio = ensureOpenExercise((int) $empresa->idempresa);
+    }
+
     Tools::settingsSet('default', 'codpais', $codpais);
     Tools::settingsSet('default', 'coddivisa', 'EUR');
     Tools::settingsSet('default', 'codimpuesto', $defaultTax);
     Tools::settingsSet('default', 'codpago', Tools::settings('default', 'codpago', 'CONT') ?: 'CONT');
-    Tools::settingsSet('default', 'codserie', Tools::settings('default', 'codserie', 'A') ?: 'A');
+    Tools::settingsSet('default', 'codserie', $codserie);
+    Tools::settingsSet('default', 'codserierec', Tools::settings('default', 'codserierec', 'R') ?: 'R');
     Tools::settingsSet('default', 'tipoidfiscal', 'NIF');
     Tools::settingsSet('default', 'regimeniva', $regimenIva);
     Tools::settingsSet('default', 'updatesupplierprices', true);
@@ -150,16 +157,92 @@ function configureBillingDefaults(): void
         Tools::settingsSet('default', 'idempresa', $empresa->idempresa);
     }
     Tools::settingsSave();
-    echo "[AiScan] Default tax: {$defaultTax}; warehouse: " . ($codalmacen ?: '(none)') . ".\n";
 
-    ensureAccountingPlan($codpais);
+    // Admin user defaults (serie is read when creating purchase documents).
+    $user = new \FacturaScripts\Dinamic\Model\User();
+    if ($user->loadFromCode(getenv('FS_INITIAL_USER') ?: 'admin')) {
+        $user->codserie = $codserie;
+        if ($codalmacen !== '') {
+            $user->codalmacen = $codalmacen;
+        }
+        if ($empresaReady) {
+            $user->idempresa = $empresa->idempresa;
+        }
+        $user->save();
+    }
+
+    echo "[AiScan] Defaults: tax={$defaultTax}, serie={$codserie}"
+        . ($codejercicio !== '' ? ", ejercicio={$codejercicio}" : '')
+        . ", warehouse=" . ($codalmacen ?: '(none)') . ".\n";
+
+    ensureAccountingPlan($codpais, $codejercicio !== '' ? $codejercicio : null);
+}
+
+/**
+ * Ensure serie "A" (general) exists and return its code for app defaults.
+ */
+function ensureDefaultSerie(): string
+{
+    $codserie = getenv('FS_DEFAULT_SERIE') ?: 'A';
+    $serie = new \FacturaScripts\Dinamic\Model\Serie();
+    if (!$serie->loadFromCode($codserie)) {
+        $serie->codserie = $codserie;
+        $serie->descripcion = $codserie === 'A' ? 'General' : $codserie;
+        if (!$serie->save()) {
+            echo "[AiScan] WARNING: could not create serie {$codserie}.\n";
+            $fallback = new \FacturaScripts\Dinamic\Model\Serie();
+            foreach ($fallback->all([], [], 0, 1) as $first) {
+                return (string) $first->codserie;
+            }
+            return $codserie;
+        }
+        echo "[AiScan] Serie created: {$codserie}.\n";
+    }
+
+    // Rectifying series used by country defaults.
+    $rec = new \FacturaScripts\Dinamic\Model\Serie();
+    if (!$rec->loadFromCode('R')) {
+        $rec->codserie = 'R';
+        $rec->descripcion = 'Rectificativas';
+        $rec->tipo = 'R';
+        $rec->save();
+    }
+
+    return $codserie;
+}
+
+/**
+ * Ensure an open accounting exercise covering today's date for the company.
+ * Documents resolve codejercicio from fecha via Ejercicio::loadFromDate().
+ */
+function ensureOpenExercise(int $idempresa): string
+{
+    $ejercicio = new \FacturaScripts\Dinamic\Model\Ejercicio();
+    $ejercicio->idempresa = $idempresa;
+    $today = date('d-m-Y');
+    if (!$ejercicio->loadFromDate($today, true, true)) {
+        echo "[AiScan] WARNING: could not load/create open exercise for {$today}.\n";
+        return '';
+    }
+
+    if (!$ejercicio->isOpened()) {
+        $ejercicio->estado = \FacturaScripts\Dinamic\Model\Ejercicio::EXERCISE_STATUS_OPEN;
+        $ejercicio->save();
+    }
+
+    echo "[AiScan] Open exercise: {$ejercicio->codejercicio}"
+        . " ({$ejercicio->fechainicio} – {$ejercicio->fechafin}).\n";
+
+    return (string) $ejercicio->codejercicio;
 }
 
 /**
  * Import the country default accounting plan when no accounts exist yet.
  * Required so posted invoices can generate asientos with IGIC subcuentas.
+ *
+ * @param string|null $codejercicio Prefer the open exercise for today when provided.
  */
-function ensureAccountingPlan(string $codpais): void
+function ensureAccountingPlan(string $codpais, ?string $codejercicio = null): void
 {
     $cuenta = new \FacturaScripts\Dinamic\Model\Cuenta();
     if ($cuenta->count() > 0) {
@@ -173,11 +256,14 @@ function ensureAccountingPlan(string $codpais): void
         return;
     }
 
-    $ejercicio = new \FacturaScripts\Dinamic\Model\Ejercicio();
-    $ejercicios = $ejercicio->all([], [], 0, 1);
-    if (empty($ejercicios)) {
-        echo "[AiScan] WARNING: no exercise found; cannot import accounting plan.\n";
-        return;
+    if ($codejercicio === null || $codejercicio === '') {
+        $ejercicio = new \FacturaScripts\Dinamic\Model\Ejercicio();
+        $ejercicios = $ejercicio->all([], [], 0, 1);
+        if (empty($ejercicios)) {
+            echo "[AiScan] WARNING: no exercise found; cannot import accounting plan.\n";
+            return;
+        }
+        $codejercicio = (string) $ejercicios[0]->codejercicio;
     }
 
     $importClass = '\\FacturaScripts\\Dinamic\\Lib\\Accounting\\AccountingPlanImport';
@@ -186,8 +272,8 @@ function ensureAccountingPlan(string $codpais): void
         return;
     }
 
-    (new $importClass())->importCSV($planFile, $ejercicios[0]->codejercicio);
-    echo "[AiScan] Accounting plan imported for exercise {$ejercicios[0]->codejercicio}.\n";
+    (new $importClass())->importCSV($planFile, $codejercicio);
+    echo "[AiScan] Accounting plan imported for exercise {$codejercicio}.\n";
 }
 
 function configureApiKeys(): void

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Playground / Docker listos para facturar con IGIC**: `blueprint.json` configura empresa
+  canaria, impuesto por defecto `IGIC7`, plan contable (`defaultplan`), formas de pago/serie
+  y productos con IGIC; `docker/setup-aiscan.php` alinea empresa, defaults y plan contable
+  en el stack local para poder crear asientos al importar facturas de compra.
 - **Entrada manual ante fallo de IA** (#67): si el escaneo falla (red, HTTP, JSON inválido,
   sin API key) o el usuario elige «Entrada manual», el panel lateral se muestra vacío y
   editable con un aviso no bloqueante. El guardado/importación funciona igual que con

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 - **Playground / Docker listos para facturar con IGIC**: `blueprint.json` configura empresa
   canaria, impuesto por defecto `IGIC7`, plan contable (`defaultplan`), formas de pago/serie
-  y productos con IGIC; `docker/setup-aiscan.php` alinea empresa, defaults y plan contable
-  en el stack local para poder crear asientos al importar facturas de compra.
+  y productos con IGIC; `docker/setup-aiscan.php` alinea empresa, defaults, **serie A**,
+  **ejercicio abierto del año en curso** y plan contable en el stack local para poder crear
+  asientos al importar facturas de compra.
 - **Entrada manual ante fallo de IA** (#67): si el escaneo falla (red, HTTP, JSON inválido,
   sin API key) o el usuario elige «Entrada manual», el panel lateral se muestra vacío y
   editable con un aviso no bloqueante. El guardado/importación funciona igual que con

--- a/docs/adr/0003-docker-auto-setup-and-seed-data.md
+++ b/docs/adr/0003-docker-auto-setup-and-seed-data.md
@@ -59,7 +59,9 @@ section so the browser playground and the Docker stack share the same billing-re
 
 - **install**: company in Santa Cruz de Tenerife, `codimpuesto=IGIC7`, `defaultplan=true`
   (imports the Spanish PGC so invoices can generate asientos).
-- **settings.default**: `codimpuesto=IGIC7`, `codpago=CONT`, `codserie=A`, EUR, NIF.
+- **settings.default**: `codimpuesto=IGIC7`, `codpago=CONT`, `codserie=A`, `codserierec=R`, EUR, NIF.
+  Docker also ensures an open ejercicio for today and assigns serie `A` to the admin user
+  (documents resolve `codejercicio` from the invoice date via `Ejercicio::loadFromDate`).
 - **seed**: Canarias suppliers, one demo customer, and products with IGIC (7% / 0%).
 
 ESP country data already ships IVA + IGIC + IPSI tax rows; the default is switched from

--- a/docs/adr/0003-docker-auto-setup-and-seed-data.md
+++ b/docs/adr/0003-docker-auto-setup-and-seed-data.md
@@ -54,7 +54,22 @@ environment:
 
 ### blueprint.json
 
-Extended with an `install` section (for the playground) and a `seed` section containing 5 Spanish suppliers and 10 products (services, materials, hardware) for realistic testing.
+Extended with an `install` section (for the playground), a `settings` section and a `seed`
+section so the browser playground and the Docker stack share the same billing-ready demo:
+
+- **install**: company in Santa Cruz de Tenerife, `codimpuesto=IGIC7`, `defaultplan=true`
+  (imports the Spanish PGC so invoices can generate asientos).
+- **settings.default**: `codimpuesto=IGIC7`, `codpago=CONT`, `codserie=A`, EUR, NIF.
+- **seed**: Canarias suppliers, one demo customer, and products with IGIC (7% / 0%).
+
+ESP country data already ships IVA + IGIC + IPSI tax rows; the default is switched from
+mainland `IVA21` to `IGIC7` so extracted Canary invoices map and post correctly.
+
+### docker/setup-aiscan.php
+
+In addition to enabling the plugin and wiring API keys, applies company address / IGIC
+defaults from env vars (`FS_DEFAULT_TAX`, `FS_COMPANY_*`) and imports the accounting plan
+when missing (`AccountingPlanImport` over `defaultPlan.csv`).
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

- Completes `blueprint.json` so FacturaScripts Playground starts ready to **invoice with IGIC** (Canary Islands company, `codimpuesto=IGIC7`, `defaultplan` for the Spanish PGC, default payment/serie, suppliers and products with IGIC).
- Aligns Docker auto-setup (`docker-compose.yml` + `docker/setup-aiscan.php`) with the same defaults and ensures warehouse settings + accounting plan when missing.
- Documents the billing-ready seed in QUICKSTART, ADR-0003 and CHANGELOG.

## Why

Testing AiScan end-to-end (scan → review → import → asiento) needs more than suppliers/products: taxes (IGIC), default tax code, warehouse and the chart of accounts. ESP country data already ships IGIC rows (`IGIC0`…`IGIC20`); the default was mainland `IVA21`.

## Blueprint highlights

| Area | Value |
| --- | --- |
| Company | Pepita Gómez - Autónoma, SCT / Canarias |
| Default tax | `IGIC7` |
| Accounting plan | `defaultplan: true` |
| Settings | `codpago=CONT`, `codserie=A`, EUR |
| Products | IGIC7 / IGIC0, purchase-ready services |

## Test plan

- [ ] Fresh playground scope with this blueprint: company shows Canarias address, default tax IGIC 7%, Contabilidad has PGC accounts.
- [ ] Import a fixture (e.g. `F-2025-004` / mock) and confirm line tax `IGIC7` and asiento includes IGIC subcuentas.
- [ ] `make upd` (or re-run `docker/setup-aiscan.php`): defaults `codimpuesto=IGIC7`, `codalmacen` set, plan contable present.
- [ ] `make lint` / `make test` still green.